### PR TITLE
Alterar links das redes sociais do perfil dos mentorados

### DIFF
--- a/profiles/pupils/profiles/AdelmoJunior.md
+++ b/profiles/pupils/profiles/AdelmoJunior.md
@@ -11,6 +11,6 @@ Ser um bom desenvolvedor front-end e trabalhar na start-up pagar.me ou então na
 
 ## Alguns links para me conhecer melhor:
 
+- [Twitter](https://twitter.com/adelmojnr)
 
-[Twitter](https://twitter.com/adelmojnr)
-[Github](https://github.com/adelmojnr)
+- [Github](https://github.com/adelmojnr)

--- a/profiles/pupils/profiles/AdelmoJunior.md
+++ b/profiles/pupils/profiles/AdelmoJunior.md
@@ -12,5 +12,4 @@ Ser um bom desenvolvedor front-end e trabalhar na start-up pagar.me ou então na
 ## Alguns links para me conhecer melhor:
 
 - [Twitter](https://twitter.com/adelmojnr)
-
 - [Github](https://github.com/adelmojnr)

--- a/profiles/pupils/profiles/AdelmoJunior.md
+++ b/profiles/pupils/profiles/AdelmoJunior.md
@@ -8,7 +8,6 @@ Adelmo Junior
 
 Ser um bom desenvolvedor front-end e trabalhar na start-up pagar.me ou então na globo.com
 
-
 ## Alguns links para me conhecer melhor:
 
 - [Twitter](https://twitter.com/adelmojnr)

--- a/profiles/pupils/profiles/AdeonirKohl.md
+++ b/profiles/pupils/profiles/AdeonirKohl.md
@@ -15,4 +15,4 @@ Quero me aperfeiçoar para trocar de carreira e seguir como front-end dev fullti
 - [Twitter](http://www.twitter.com/adeonir)
 - [Facebook](http://www.facebook.com/adeonir)
 - [LinkedIn](https://br.linkedin.com/in/adeonir-kohl-85599420)
-- [adeonir@gmail.com](adeonir@gmail.com)
+- [Email](mailto:adeonir@gmail.com)

--- a/profiles/pupils/profiles/AdeonirKohl.md
+++ b/profiles/pupils/profiles/AdeonirKohl.md
@@ -12,10 +12,10 @@ Quero me aperfeiçoar para trocar de carreira e seguir como front-end dev fullti
 
 ## Alguns links para me conhecer melhor:
 
-[Twitter](http://www.twitter.com/adeonir)
+- [Twitter](http://www.twitter.com/adeonir)
 
-[Facebook](http://www.facebook.com/adeonir)
+- [Facebook](http://www.facebook.com/adeonir)
 
-[LinkedIn](https://br.linkedin.com/in/adeonir-kohl-85599420)
+- [LinkedIn](https://br.linkedin.com/in/adeonir-kohl-85599420)
 
-[adeonir@gmail.com](adeonir@gmail.com)
+- [adeonir@gmail.com](adeonir@gmail.com)

--- a/profiles/pupils/profiles/AdeonirKohl.md
+++ b/profiles/pupils/profiles/AdeonirKohl.md
@@ -13,9 +13,6 @@ Quero me aperfeiçoar para trocar de carreira e seguir como front-end dev fullti
 ## Alguns links para me conhecer melhor:
 
 - [Twitter](http://www.twitter.com/adeonir)
-
 - [Facebook](http://www.facebook.com/adeonir)
-
 - [LinkedIn](https://br.linkedin.com/in/adeonir-kohl-85599420)
-
 - [adeonir@gmail.com](adeonir@gmail.com)

--- a/profiles/pupils/profiles/AlexAvila.md
+++ b/profiles/pupils/profiles/AlexAvila.md
@@ -14,5 +14,5 @@ Iniciar uma carreira como front-end developer, de preferência como home office,
 ## Alguns links para me conhecer melhor:
 
 
-[Twitter do Alex Ávila](http://www.twitter.com/alexavila)
-[LinkedIn do Alex Ávila](http://www.linkedin.com/alexdeavila)
+- [Twitter](http://www.twitter.com/alexavila)
+- [LinkedIn](http://www.linkedin.com/alexdeavila)

--- a/profiles/pupils/profiles/AlexAvila.md
+++ b/profiles/pupils/profiles/AlexAvila.md
@@ -10,9 +10,7 @@ Alex Ávila
 
 Iniciar uma carreira como front-end developer, de preferência como home office, aprender muito e me tornar mentor. Também quero iniciar um mestrado em design de interação para poder dar aulas.
 
-
 ## Alguns links para me conhecer melhor:
-
 
 - [Twitter](http://www.twitter.com/alexavila)
 - [LinkedIn](http://www.linkedin.com/alexdeavila)

--- a/profiles/pupils/profiles/AlexBarazal.md
+++ b/profiles/pupils/profiles/AlexBarazal.md
@@ -12,7 +12,8 @@ Quero me aperfeiçoar até estar apto como gerente de projetos mais no momento
 busco oportunidade em desenvolvimento Web. É uma orientação quais linguagens
 deveria me dedicar mais para buscar produtividade e performance.
 
-#Conhecimentos
+## Conhecimentos
+
 Conheço diversas linguagem como Java, JavaEE, C#, PHP, Android, CSS, Javascrit, html5 entre outras mais meus conhecimentos acadêmicos estou fazendo diversos cursos aleatórios, mais busco desenvolver meus conhecimentos direcionando para web e mobile.
 Atualmente estou desenvolvendo um projeto com outros alunos para desenvolver nossas habilidades como desenvolvedor mais a grande dificuldade e não conhecer o ambiente real de produção, gostaria através desse projeto orientação para me desenvolver profissionalmente e também partilhar esse conhecimento.
 Estou aberto para qualquer esclarecimento e duvidas.

--- a/profiles/pupils/profiles/AlexBarazal.md
+++ b/profiles/pupils/profiles/AlexBarazal.md
@@ -19,7 +19,7 @@ Estou aberto para qualquer esclarecimento e duvidas.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Alex Santana Barazal](https://www.facebook.com/alex.santanabarazal)<br/>
-[Twitter do Alex Santana Barazal](https://twitter.com/_LastResort)<br/>
-[LinkedIn do Alex Santana Barazal](https://br.linkedin.com/in/alex-santana-barazal-0938a821)<br/>
-[GitHub do Alex Santana Barazal](https://github.com/AlexBarazal)<br/>
+- [Facebook](https://www.facebook.com/alex.santanabarazal)<br/>
+- [Twitter](https://twitter.com/_LastResort)<br/>
+- [LinkedIn](https://br.linkedin.com/in/alex-santana-barazal-0938a821)<br/>
+- [GitHub](https://github.com/AlexBarazal)<br/>

--- a/profiles/pupils/profiles/AlexBarazal.md
+++ b/profiles/pupils/profiles/AlexBarazal.md
@@ -19,7 +19,7 @@ Estou aberto para qualquer esclarecimento e duvidas.
 
 ## Alguns links para me conhecer melhor
 
-- [Facebook](https://www.facebook.com/alex.santanabarazal)<br/>
-- [Twitter](https://twitter.com/_LastResort)<br/>
-- [LinkedIn](https://br.linkedin.com/in/alex-santana-barazal-0938a821)<br/>
-- [GitHub](https://github.com/AlexBarazal)<br/>
+- [Facebook](https://www.facebook.com/alex.santanabarazal)
+- [Twitter](https://twitter.com/_LastResort)
+- [LinkedIn](https://br.linkedin.com/in/alex-santana-barazal-0938a821)
+- [GitHub](https://github.com/AlexBarazal)

--- a/profiles/pupils/profiles/AllanRamos.md
+++ b/profiles/pupils/profiles/AllanRamos.md
@@ -12,5 +12,5 @@ Quero ser um desenvolvedor front-end fullstack, com fortes competências na part
 
 ## Alguns links para me conhecer melhor
 
-[Linkedin](https://br.linkedin.com/in/allangabrielrds)
-[Facebook](https://www.facebook.com/allangabrielrds)
+- [Linkedin](https://br.linkedin.com/in/allangabrielrds)
+- [Facebook](https://www.facebook.com/allangabrielrds)

--- a/profiles/pupils/profiles/AndersonAltissimo.md
+++ b/profiles/pupils/profiles/AndersonAltissimo.md
@@ -14,6 +14,6 @@ ajudar os que estejam entrando na programação e que tenha dificuldades!!
 
 ## Alguns links para me conhecer melhor
 
-[Facebook] (https://www.facebook.com/people/Anderson-Altissimo/100004568926089)
-[Twitter](https://twitter.com/ander_altissimo)
-[LinkedIn](https://www.linkedin.com/in/andersonaltissimo/)
+- [Facebook](https://www.facebook.com/people/Anderson-Altissimo/100004568926089)
+- [Twitter](https://twitter.com/ander_altissimo)
+- [LinkedIn](https://www.linkedin.com/in/andersonaltissimo/)

--- a/profiles/pupils/profiles/AndersonNascimento.md
+++ b/profiles/pupils/profiles/AndersonNascimento.md
@@ -10,7 +10,6 @@ Anderson Nascimento
 
 Evoluir profissionalmente e alcançar maturidade intelectual que me possibilite resolver problemas elegantemente; contribuir com a comunidade open source.
 
-
 ## Alguns links para me conhecer melhor:
 
 - [Twitter](https://twitter.com/theandersonn)

--- a/profiles/pupils/profiles/AndreAlmeida.md
+++ b/profiles/pupils/profiles/AndreAlmeida.md
@@ -12,4 +12,4 @@ Ser um desenvolvedor Full-Stack e além de trabalhar na área, ajudar quem preci
 
 ## Alguns links para me conhecer melhor
 
-[GitHub](https://github.com/alfalmeida)
+- [GitHub](https://github.com/alfalmeida)

--- a/profiles/pupils/profiles/AndreFerreira.md
+++ b/profiles/pupils/profiles/AndreFerreira.md
@@ -12,6 +12,6 @@ Ser um programador especialista em blockchain, construir um projeto de sucesso p
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/aferreira44)
-[Twitter](https://www.facebook.com/aferreira44)
-[LinkedIn](https://www.linkedin.com/in/aferreira44/)
+- [Facebook](https://www.facebook.com/aferreira44)
+- [Twitter](https://www.facebook.com/aferreira44)
+- [LinkedIn](https://www.linkedin.com/in/aferreira44/)

--- a/profiles/pupils/profiles/AndreTeles.md
+++ b/profiles/pupils/profiles/AndreTeles.md
@@ -12,6 +12,6 @@ Desejo ingressar no mercado de trabalho como desenvolvedor Web e ser o melhor no
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/andre.pereirateles)
-[Twitter](https://twitter.com/andretpsimply)
-[Trampos](https://trampos.co/andre-teles)
+- [Facebook](https://www.facebook.com/andre.pereirateles)
+- [Twitter](https://twitter.com/andretpsimply)
+- [Trampos](https://trampos.co/andre-teles)

--- a/profiles/pupils/profiles/AndreyBevilacqua.md
+++ b/profiles/pupils/profiles/AndreyBevilacqua.md
@@ -12,4 +12,4 @@ Ser um excelente desenvolvedor Java. Ser independente profissionalmente, crescer
 
 ## Alguns links para me conhecer melhor
 
-[LinkedIn](https://br.linkedin.com/in/andreybevilacqua)
+- [LinkedIn](https://br.linkedin.com/in/andreybevilacqua)

--- a/profiles/pupils/profiles/AugustoAlmeida.md
+++ b/profiles/pupils/profiles/AugustoAlmeida.md
@@ -16,4 +16,4 @@ Quero conseguir um emprego como desenvolvedor, trabalhando com o que eu gosto e 
 - [Site pessoal](http://agadev.com.br)
 - [Linkedin](https://br.linkedin.com/in/agadev)
 - [GitHub](https://github.com/agadev-bh)
-- [Email](agadevbh@gmail.com)
+- [Email](mailto:agadevbh@gmail.com)

--- a/profiles/pupils/profiles/AugustoAlmeida.md
+++ b/profiles/pupils/profiles/AugustoAlmeida.md
@@ -12,8 +12,8 @@ Quero conseguir um emprego como desenvolvedor, trabalhando com o que eu gosto e 
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/agadevbh)
-[Site pessoal](http://agadev.com.br)
-[Linkedin](https://br.linkedin.com/in/agadev)
-[GitHub](https://github.com/agadev-bh)
+- [Facebook](https://www.facebook.com/agadevbh)
+- [Site pessoal](http://agadev.com.br)
+- [Linkedin](https://br.linkedin.com/in/agadev)
+- [GitHub](https://github.com/agadev-bh)
 agadevbh@gmail.com

--- a/profiles/pupils/profiles/AugustoAlmeida.md
+++ b/profiles/pupils/profiles/AugustoAlmeida.md
@@ -16,4 +16,4 @@ Quero conseguir um emprego como desenvolvedor, trabalhando com o que eu gosto e 
 - [Site pessoal](http://agadev.com.br)
 - [Linkedin](https://br.linkedin.com/in/agadev)
 - [GitHub](https://github.com/agadev-bh)
-agadevbh@gmail.com
+- [Email](agadevbh@gmail.com)

--- a/profiles/pupils/profiles/BeatrizUezu.md
+++ b/profiles/pupils/profiles/BeatrizUezu.md
@@ -12,5 +12,5 @@ Ser desenvolvedora full stack e trabalhar fora do país.
 
 ## Alguns links para me conhecer melhor:
 
-[Twitter](http://www.twitter.com/beatrizuezu)
-[LinkedIn](https://br.linkedin.com/in/beatrizuezu)
+- [Twitter](http://www.twitter.com/beatrizuezu)
+- [LinkedIn](https://br.linkedin.com/in/beatrizuezu)

--- a/profiles/pupils/profiles/BrenoLemos.md
+++ b/profiles/pupils/profiles/BrenoLemos.md
@@ -12,6 +12,6 @@ Me desenvolver como um bom desenvolvedor front end, conseguir um emprego na áre
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/breno.lemos.9)
-[Github](http://github.com/brennolemos)
-[LinkedIn](https://www.linkedin.com/in/breno-lemos-049374104)
+- [Facebook](https://www.facebook.com/breno.lemos.9)
+- [Github](http://github.com/brennolemos)
+- [LinkedIn](https://www.linkedin.com/in/breno-lemos-049374104)

--- a/profiles/pupils/profiles/BrunoCavalcante.md
+++ b/profiles/pupils/profiles/BrunoCavalcante.md
@@ -14,6 +14,6 @@ Bruno Cavalcante
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/brncavalcante)
-[Twitter](https://twitter.com/brncavalcante)
-[LinkedIn](https://br.linkedin.com/in/brncavalcante)
+- [Facebook](https://www.facebook.com/brncavalcante)
+- [Twitter](https://twitter.com/brncavalcante)
+- [LinkedIn](https://br.linkedin.com/in/brncavalcante)

--- a/profiles/pupils/profiles/BrunoFerreira.md
+++ b/profiles/pupils/profiles/BrunoFerreira.md
@@ -12,6 +12,6 @@ Sempre em busca de me tornar um desenvolvedor full-stack cada vez mais capacitad
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/fsbrunoferreira)
-[GitHub](https://github.com/brunoferreiras)
-[LinkedIn](https://www.linkedin.com/in/bruno-ferreira-91547310b)
+- [Facebook](https://www.facebook.com/fsbrunoferreira)
+- [GitHub](https://github.com/brunoferreiras)
+- [LinkedIn](https://www.linkedin.com/in/bruno-ferreira-91547310b)

--- a/profiles/pupils/profiles/BrunoMelo.md
+++ b/profiles/pupils/profiles/BrunoMelo.md
@@ -13,5 +13,4 @@ Quero conseguir um emprego como Front-End
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/brunooomelo)
-
-- [LinkedIn](https://www.linkedin.com/in/brunomelo94?trk=hp-identity-photo)
+- [LinkedIn](https://www.linkedin.com/in/brunomelo94)

--- a/profiles/pupils/profiles/BrunoMelo.md
+++ b/profiles/pupils/profiles/BrunoMelo.md
@@ -12,6 +12,6 @@ Quero conseguir um emprego como Front-End
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/brunooomelo)
+- [Facebook](https://www.facebook.com/brunooomelo)
 
-[LinkedIn](https://www.linkedin.com/in/brunomelo94?trk=hp-identity-photo)
+- [LinkedIn](https://www.linkedin.com/in/brunomelo94?trk=hp-identity-photo)

--- a/profiles/pupils/profiles/Bruno_Martins.md
+++ b/profiles/pupils/profiles/Bruno_Martins.md
@@ -12,4 +12,4 @@ Quero me tornar um bom profissional e um dia poder repassar o que eu aprender
 
 ## Alguns links para me conhecer melhor
 
-- [Twitter](https://twitter.com/3ru_Martins?)
+- [Twitter](https://twitter.com/3ru_Martins)

--- a/profiles/pupils/profiles/Bruno_Martins.md
+++ b/profiles/pupils/profiles/Bruno_Martins.md
@@ -12,4 +12,4 @@ Quero me tornar um bom profissional e um dia poder repassar o que eu aprender
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/3ru_Martins?lang=pt-br)
+- [Twitter](https://twitter.com/3ru_Martins?lang=pt-br)

--- a/profiles/pupils/profiles/Bruno_Martins.md
+++ b/profiles/pupils/profiles/Bruno_Martins.md
@@ -12,4 +12,4 @@ Quero me tornar um bom profissional e um dia poder repassar o que eu aprender
 
 ## Alguns links para me conhecer melhor
 
-- [Twitter](https://twitter.com/3ru_Martins?lang=pt-br)
+- [Twitter](https://twitter.com/3ru_Martins?)

--- a/profiles/pupils/profiles/CelsoLopes.md
+++ b/profiles/pupils/profiles/CelsoLopes.md
@@ -12,5 +12,5 @@ Ser um bom desenvolvedor fullstack e trabalhar em start-up ou ter uma carteira d
 
 ## Alguns links para me conhecer melhor
 
-[Github](https://github.com/celsodavid)
-[LinkedIn](https://www.linkedin.com/in/celso-david-lopes-dos-santos)
+- [Github](https://github.com/celsodavid)
+- [LinkedIn](https://www.linkedin.com/in/celso-david-lopes-dos-santos)

--- a/profiles/pupils/profiles/DanielDeJesusOliveira.md
+++ b/profiles/pupils/profiles/DanielDeJesusOliveira.md
@@ -15,7 +15,5 @@ Quero adquirir experiência e conhecimento para no futuro me tornar um mentor da
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/danieloliveira138)
-
 - [GitHub](https://github.com/danieloliveira138)
-
 - [LinkedIn](https://www.linkedin.com/in/daniel-de-jesus-oliveira-bb26b770/)

--- a/profiles/pupils/profiles/DanielDeJesusOliveira.md
+++ b/profiles/pupils/profiles/DanielDeJesusOliveira.md
@@ -14,8 +14,8 @@ Quero adquirir experiência e conhecimento para no futuro me tornar um mentor da
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/danieloliveira138)
+- [Facebook](https://www.facebook.com/danieloliveira138)
 
-[GitHub](https://github.com/danieloliveira138)
+- [GitHub](https://github.com/danieloliveira138)
 
-[LinkedIn](https://www.linkedin.com/in/daniel-de-jesus-oliveira-bb26b770/)
+- [LinkedIn](https://www.linkedin.com/in/daniel-de-jesus-oliveira-bb26b770/)

--- a/profiles/pupils/profiles/DanielDiniz.md
+++ b/profiles/pupils/profiles/DanielDiniz.md
@@ -14,4 +14,4 @@ Criar uma start up e trabalhar com aplicativos.
 ## Alguns links para me conhecer melhor:
 
 
-[Github](https://github.com/danieldnz)
+- [Github](https://github.com/danieldnz)

--- a/profiles/pupils/profiles/DanielDiniz.md
+++ b/profiles/pupils/profiles/DanielDiniz.md
@@ -10,8 +10,6 @@ Daniel Diniz Rainha da Cunha
 
 Criar uma start up e trabalhar com aplicativos.
 
-
 ## Alguns links para me conhecer melhor:
-
 
 - [Github](https://github.com/danieldnz)

--- a/profiles/pupils/profiles/EduardoSdeAraujo.md
+++ b/profiles/pupils/profiles/EduardoSdeAraujo.md
@@ -13,5 +13,5 @@ Eduardo S. de Araujo
 
 # Alguns links para me conhecer melhor
 
-https://www.facebook.com/eduardo.s.de.araujo
-https://www.linkedin.com/in/edusaraujo
+- [Facebook](https://www.facebook.com/eduardo.s.de.araujo)
+- [LinkedIn](https://www.linkedin.com/in/edusaraujo)

--- a/profiles/pupils/profiles/EmanuelG.md
+++ b/profiles/pupils/profiles/EmanuelG.md
@@ -12,7 +12,7 @@ Ser um bom desenvolvedor, que possa contribuir com a web de forma a torná-la ma
 
 ## Alguns links para me conhecer melhor
 
-[Meu Facebook](https://www.facebook.com/emanuelgdev)
-[Meu Github](https://github.com/emanuelgsouza)
-[Meu Linkedin](https://br.linkedin.com/in/emanuelgsouza)
-[Meu site](http://emanuelgdev.com.br/)
+- [Facebook](https://www.facebook.com/emanuelgdev)
+- [Github](https://github.com/emanuelgsouza)
+- [Linkedin](https://br.linkedin.com/in/emanuelgsouza)
+- [Site](http://emanuelgdev.com.br/)

--- a/profiles/pupils/profiles/EnieberCunha.md
+++ b/profiles/pupils/profiles/EnieberCunha.md
@@ -19,6 +19,6 @@ coisas, e por isso sei um pouco de programação funcional, com Erlang e Elixir.
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/enieber)
-[Github](https://github.com/enieber)
-[Blog](https://enieber.github.io/)
+- [Twitter](https://twitter.com/enieber)
+- [Github](https://github.com/enieber)
+- [Blog](https://enieber.github.io/)

--- a/profiles/pupils/profiles/EricMadureira.md
+++ b/profiles/pupils/profiles/EricMadureira.md
@@ -12,6 +12,6 @@ Ter experiência de Home Office, trabalhar em outro país e aprender bastante pr
 
 ## Alguns links para me conhecer melhor
 
-* [Facebook](https://www.facebook.com/eric.madureira.2)
-* [Twitter](https://twitter.com/housemadx)
-* [LinkedIn](https://www.linkedin.com/in/eric-madureira-23b6aa100/)
+- [Facebook](https://www.facebook.com/eric.madureira.2)
+- [Twitter](https://twitter.com/housemadx)
+- [LinkedIn](https://www.linkedin.com/in/eric-madureira-23b6aa100/)

--- a/profiles/pupils/profiles/ErikG_matos.md
+++ b/profiles/pupils/profiles/ErikG_matos.md
@@ -13,5 +13,5 @@ Me tornar um profissional de Front End, aprendendo de forma contínua, sempre co
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/matosg_erik)
-[LinkedIn](https://www.linkedin.com/in/erikgarcesmatos/)
+- [Twitter](https://twitter.com/matosg_erik)
+- [LinkedIn](https://www.linkedin.com/in/erikgarcesmatos/)

--- a/profiles/pupils/profiles/ErikG_matos.md
+++ b/profiles/pupils/profiles/ErikG_matos.md
@@ -9,7 +9,7 @@ Erik Garces Matos
 ## Qual meu sonho na carreira?
 
 Me tornar um profissional de Front End, aprendendo de forma contínua, sempre com dedicação e força de vontade!
-*Nunca tive experiêcia profissional na area.
+*Nunca tive experiêcia profissional na area*.
 
 ## Alguns links para me conhecer melhor
 

--- a/profiles/pupils/profiles/Eviceconti.md
+++ b/profiles/pupils/profiles/Eviceconti.md
@@ -12,4 +12,4 @@ Quero conseguir um emprego como Front-End
 
 ## Alguns links para me conhecer melhor 
 
-[Twitter](https://mobile.twitter.com/vicecontie)
+- [Twitter](https://mobile.twitter.com/vicecontie)

--- a/profiles/pupils/profiles/FelipeAcelino.md
+++ b/profiles/pupils/profiles/FelipeAcelino.md
@@ -18,5 +18,5 @@ Sou um pequeno gafanhoto. Trabalho com PHP mas sou apaixonado por desenvolviment
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/felipesilva10)
-[Twitter](https://twitter.com/felipe_acelino)
+- [Facebook](https://www.facebook.com/felipesilva10)
+- [Twitter](https://twitter.com/felipe_acelino)

--- a/profiles/pupils/profiles/FelipeLacerda.md
+++ b/profiles/pupils/profiles/FelipeLacerda.md
@@ -16,5 +16,5 @@ Tenho conehcimento em PHP, banco de dados MySql. E tenho estudado bastante o Lar
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/lipe.lacerda)
-[Twitter](https://twitter.com/flacerda)
+- [Facebook](https://www.facebook.com/lipe.lacerda)
+- [Twitter](https://twitter.com/flacerda)

--- a/profiles/pupils/profiles/FelipeRSAbbud.md
+++ b/profiles/pupils/profiles/FelipeRSAbbud.md
@@ -12,6 +12,6 @@ Conseguir criar soluções úteis para problemas reais. Quero melhorar minhas ha
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/profile.php?id=100003234835606&ref=bookmarks)
-[Twitter](https://twitter.com/Feabbud)
-[LinkedIn](https://br.linkedin.com/in/felipe-ricardo-silveira-abbud-12561230)
+- [Facebook](https://www.facebook.com/profile.php?id=100003234835606&ref=bookmarks)
+- [Twitter](https://twitter.com/Feabbud)
+- [LinkedIn](https://br.linkedin.com/in/felipe-ricardo-silveira-abbud-12561230)

--- a/profiles/pupils/profiles/FernandoCosta.md
+++ b/profiles/pupils/profiles/FernandoCosta.md
@@ -12,5 +12,5 @@ Desenvolver algo que possa impactar o mundo!
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/Fernando.Coastt)  
-[LinkedIn](https://www.linkedin.com/in/fernando-costa-nogueira/)
+- [Facebook](https://www.facebook.com/Fernando.Coastt)  
+- [LinkedIn](https://www.linkedin.com/in/fernando-costa-nogueira/)

--- a/profiles/pupils/profiles/FernandoMartins.md
+++ b/profiles/pupils/profiles/FernandoMartins.md
@@ -12,5 +12,5 @@ Meus sonhos atualmente é de me formar na faculdade e conseguir algum estágio/e
 
 ## Alguns links para me conhecer melhor
 
-- [Facebook ](https://facebook.com/fernando.martins.3551)
-- [LinkedIn ](https://br.linkedin.com/in/fernando-antônio-martins-vieira-júnior-b09524a4)
+- [Facebook](https://facebook.com/fernando.martins.3551)
+- [LinkedIn](https://br.linkedin.com/in/fernando-antônio-martins-vieira-júnior-b09524a4)

--- a/profiles/pupils/profiles/FernandoMartins.md
+++ b/profiles/pupils/profiles/FernandoMartins.md
@@ -12,5 +12,5 @@ Meus sonhos atualmente é de me formar na faculdade e conseguir algum estágio/e
 
 ## Alguns links para me conhecer melhor
 
-[Facebook ](https://facebook.com/fernando.martins.3551)
-[LinkedIn ](https://br.linkedin.com/in/fernando-antônio-martins-vieira-júnior-b09524a4)
+- [Facebook ](https://facebook.com/fernando.martins.3551)
+- [LinkedIn ](https://br.linkedin.com/in/fernando-antônio-martins-vieira-júnior-b09524a4)

--- a/profiles/pupils/profiles/G18Siqueira.md
+++ b/profiles/pupils/profiles/G18Siqueira.md
@@ -12,6 +12,6 @@ Me tornar um desenvolvedor front-end capaz de codar o que vier na cabeça e cons
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/GuhhSiqueira)
+- [Facebook](https://www.facebook.com/GuhhSiqueira)
 
-[Twitter](https://twitter.com/Guhh_Siqueira)
+- [Twitter](https://twitter.com/Guhh_Siqueira)

--- a/profiles/pupils/profiles/G18Siqueira.md
+++ b/profiles/pupils/profiles/G18Siqueira.md
@@ -13,5 +13,4 @@ Me tornar um desenvolvedor front-end capaz de codar o que vier na cabeça e cons
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/GuhhSiqueira)
-
 - [Twitter](https://twitter.com/Guhh_Siqueira)

--- a/profiles/pupils/profiles/GabrielBerto.md
+++ b/profiles/pupils/profiles/GabrielBerto.md
@@ -9,5 +9,5 @@ Gabriel Berto de Castro Barbosa
 Trabalhar em uma empresa grande (talves que eu seja o dono) desenvolvendo soluções inovadoras para os mais variados problemas.
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/gabriel.berto.102)
-[LinkedIn](https://www.linkedin.com/in/gabriel-berto)
+- [Facebook](https://www.facebook.com/gabriel.berto.102)
+- [LinkedIn](https://www.linkedin.com/in/gabriel-berto)

--- a/profiles/pupils/profiles/GabrielBerto.md
+++ b/profiles/pupils/profiles/GabrielBerto.md
@@ -1,12 +1,15 @@
 # Mentor(a) responsável por mim
 
 [Kiver Teixeira](/profiles/mentors/profiles/kiver.md)
+
 ## Meu Nome
 
 Gabriel Berto de Castro Barbosa
+
 ## Qual meu sonho na carreira?
 
 Trabalhar em uma empresa grande (talves que eu seja o dono) desenvolvendo soluções inovadoras para os mais variados problemas.
+
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/gabriel.berto.102)

--- a/profiles/pupils/profiles/GabrielBrito.md
+++ b/profiles/pupils/profiles/GabrielBrito.md
@@ -9,7 +9,8 @@ Meu sonho é ser alguém que faça uma diferença enorme! Seja na comunidade ou 
 E meu sonho de vida é ter um Apê em Vancouver/Canadá xD
 
 ## Alguns links para me conhecer melhor
-[WebSite](https://gabriel-brito.github.io)
-[Twitter](https://twitter.com/mr_gabrielbp)
-[GitHub](https://github.com/gabriel-brito)
-[LinkedIn](https://www.linkedin.com/in/gbsantos)
+
+- [WebSite](https://gabriel-brito.github.io)
+- [Twitter](https://twitter.com/mr_gabrielbp)
+- [GitHub](https://github.com/gabriel-brito)
+- [LinkedIn](https://www.linkedin.com/in/gbsantos)

--- a/profiles/pupils/profiles/GabrielFerreira.md
+++ b/profiles/pupils/profiles/GabrielFerreira.md
@@ -8,6 +8,7 @@ Gabriel Ferreira
 Ser reconhecido na comunidade como desenvolvedor Front-end, conseguir 10k de views no meu CodePen e trabalhar no exterior :) 
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/gabrielferreira.sap)
-[GitHub](https://github.com/gabrielferreira)
-[LinkedIn](https://www.linkedin.com/in/gabrielferreira)
+
+- [Facebook](https://www.facebook.com/gabrielferreira.sap)
+- [GitHub](https://github.com/gabrielferreira)
+- [LinkedIn](https://www.linkedin.com/in/gabrielferreira)

--- a/profiles/pupils/profiles/GabrielVieira.md
+++ b/profiles/pupils/profiles/GabrielVieira.md
@@ -12,5 +12,5 @@ Meu objetivo é me tornar um programador PHP profissional!
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/gabriel.vieirateodoro)
-[LinkedIn](https://www.linkedin.com/in/gabriel-vieira-teodoro-b60932a7?trk=nav_responsive_tab_profile_pic)
+- [Facebook](https://www.facebook.com/gabriel.vieirateodoro)
+- [LinkedIn](https://www.linkedin.com/in/gabriel-vieira-teodoro-b60932a7?trk=nav_responsive_tab_profile_pic)

--- a/profiles/pupils/profiles/GabrielleDias.md
+++ b/profiles/pupils/profiles/GabrielleDias.md
@@ -12,4 +12,4 @@ Ser uma analista desenvolvedora.
 
 ## Alguns links para me conhecer melhor
 
-[Email](mailto:gabi_dias5@hotmail.com)
+- [Email](mailto:gabi_dias5@hotmail.com)

--- a/profiles/pupils/profiles/GuilhermeDeOliveiraCosta.md
+++ b/profiles/pupils/profiles/GuilhermeDeOliveiraCosta.md
@@ -12,5 +12,5 @@ Me desenvolver como developer ao ponto de liderar um time e alcançar o sucesso 
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/guilhermedeocosta),
-[LinkedIn](https://br.linkedin.com/in/guilhermeocosta)
+- [Facebook](https://www.facebook.com/guilhermedeocosta),
+- [LinkedIn](https://br.linkedin.com/in/guilhermeocosta)

--- a/profiles/pupils/profiles/GustavoAguiar.md
+++ b/profiles/pupils/profiles/GustavoAguiar.md
@@ -8,6 +8,6 @@ Gustavo Aguiar
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/gustavo.aguiar.359)
-[Twitter](https://twitter.com/gusttavoaguiarr)
-[LinkedIn](https://br.linkedin.com/in/gustavo-aguiar-926463110)
+- [Facebook](https://www.facebook.com/gustavo.aguiar.359)
+- [Twitter](https://twitter.com/gusttavoaguiarr)
+- [LinkedIn](https://br.linkedin.com/in/gustavo-aguiar-926463110)

--- a/profiles/pupils/profiles/HenriqueRodrigues.md
+++ b/profiles/pupils/profiles/HenriqueRodrigues.md
@@ -16,7 +16,6 @@ Henrique Rodrigues
 
 ## Alguns links para me conhecer melhor:
 
-
 [Facebook](https://www.facebook.com/hjFrontEnd)
 [Twitter](https://twitter.com/coisadedev)
 [LinkedIn](https://www.linkedin.com/in/coisadedev/)

--- a/profiles/pupils/profiles/HiranNeri.md
+++ b/profiles/pupils/profiles/HiranNeri.md
@@ -12,5 +12,5 @@ Conseguir iniciar a minha carreira (Desenvolvedor Java) em uma média/grande emp
 
 ##Alguns links para me conhecer melhor:
 
-[Twitter](https://twitter.com/devhiranneri)
-[LinkedIn](https://br.linkedin.com/in/hiranneri)
+- [Twitter](https://twitter.com/devhiranneri)
+- [LinkedIn](https://br.linkedin.com/in/hiranneri)

--- a/profiles/pupils/profiles/HiranNeri.md
+++ b/profiles/pupils/profiles/HiranNeri.md
@@ -1,16 +1,16 @@
-#Mentor responsável por mim:
+# Mentor responsável por mim:
 
 [Vinicius Tinguan](/profiles/mentors/profiles/vinicius_tinguan.md)
 
-#Meu Nome:
+# Meu Nome:
 
 Hiran Neri
 
-##Qual meu sonho na carreira?
+## Qual meu sonho na carreira?
 
 Conseguir iniciar a minha carreira (Desenvolvedor Java) em uma média/grande empresa e poder dar aulas sobre programação em alguma escola técnica conceituada. (ETEC ou outras).
 
-##Alguns links para me conhecer melhor:
+## Alguns links para me conhecer melhor:
 
 - [Twitter](https://twitter.com/devhiranneri)
 - [LinkedIn](https://br.linkedin.com/in/hiranneri)

--- a/profiles/pupils/profiles/IagoQueiroz.md
+++ b/profiles/pupils/profiles/IagoQueiroz.md
@@ -12,4 +12,4 @@ Montar uma agência de soluções Web e Mobile. Mas até lá, desejo me tornar u
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Iago Queiroz](https://www.facebook.com/iago.queiroz.14)
+- [Facebook](https://www.facebook.com/iago.queiroz.14)

--- a/profiles/pupils/profiles/IgoOliveira.md
+++ b/profiles/pupils/profiles/IgoOliveira.md
@@ -14,6 +14,6 @@ Me tornar um bom desenvolvedor e sempre melhorar minhas habilidades!
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/devigor17)
-[Twitter](https://twitter.com/_devigor)
-[Github](https://github.com/devigor)
+- [Facebook](https://www.facebook.com/devigor17)
+- [Twitter](https://twitter.com/_devigor)
+- [Github](https://github.com/devigor)

--- a/profiles/pupils/profiles/IgorAlves.md
+++ b/profiles/pupils/profiles/IgorAlves.md
@@ -18,5 +18,5 @@ Conheço o basico de HTML, JAVA, C, PHP mas sem conhecimento profundo, não sei 
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/igoralvess)
-[GitHub](https://github.com/igoralvess)
+- [Facebook](https://www.facebook.com/igoralvess)
+- [GitHub](https://github.com/igoralvess)

--- a/profiles/pupils/profiles/IngridRauany.md
+++ b/profiles/pupils/profiles/IngridRauany.md
@@ -12,6 +12,6 @@ Sempre gostei muito de programação no geral, mas nunca tive um foco, até porq
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/ingrid.rauany)<br/>
-[Twitter](https://twitter.com/ingridrauany)<br/>
-[LinkedIn](https://br.linkedin.com/in/ingridrauany)
+- [Facebook](https://www.facebook.com/ingrid.rauany)
+- [Twitter](https://twitter.com/ingridrauany)
+- [LinkedIn](https://br.linkedin.com/in/ingridrauany)

--- a/profiles/pupils/profiles/JamileLima.md
+++ b/profiles/pupils/profiles/JamileLima.md
@@ -12,4 +12,4 @@ Me aprofundar no Desenvolvimento Web e poder fazer a diferença na comunidade. :
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/fromgenes)
+- [Twitter](https://twitter.com/fromgenes)

--- a/profiles/pupils/profiles/JoseliaCosta.md
+++ b/profiles/pupils/profiles/JoseliaCosta.md
@@ -12,5 +12,5 @@ Quero dominar HTML/CSS e JavaScript a ponto de escrever um código claro, limpo 
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](http://twitter.com/meninadoviolao)  
-[LinkedIn](http//linkedin.com/in/joselialcosta)  
+- [Twitter](http://twitter.com/meninadoviolao)  
+- [LinkedIn](http//linkedin.com/in/joselialcosta)  

--- a/profiles/pupils/profiles/JulianoPadilha.md
+++ b/profiles/pupils/profiles/JulianoPadilha.md
@@ -10,6 +10,6 @@ Meu sonho de carreira é poder me consolidar como um desenvolvedor front-end, se
 
 ## Alguns links para me conhecer melhor
 
-[Facebook ](https://www.facebook.com/JulianoPadilha)
-[LinkedIn ](https://br.linkedin.com/in/julianopadilha)
-[Twitter ](https://twitter.com/padilhano)
+- [Facebook](https://www.facebook.com/JulianoPadilha)
+- [LinkedIn](https://br.linkedin.com/in/julianopadilha)
+- [Twitter](https://twitter.com/padilhano)

--- a/profiles/pupils/profiles/Kaique_Xavier_Atalla.md
+++ b/profiles/pupils/profiles/Kaique_Xavier_Atalla.md
@@ -14,6 +14,6 @@ Virar programador Front, com conhecimentos em back-end. Saber construir projetos
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://pt-br.facebook.com/kaique.xavieratalla)
-[Twitter](@kaique_xavier)
-[LinkedIn](https://www.linkedin.com/in/kaique-atalla-3a1562125/)
+- [Facebook](https://pt-br.facebook.com/kaique.xavieratalla)
+- [Twitter](@kaique_xavier)
+- [LinkedIn](https://www.linkedin.com/in/kaique-atalla-3a1562125/)

--- a/profiles/pupils/profiles/Kaique_Xavier_Atalla.md
+++ b/profiles/pupils/profiles/Kaique_Xavier_Atalla.md
@@ -15,5 +15,5 @@ Virar programador Front, com conhecimentos em back-end. Saber construir projetos
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://pt-br.facebook.com/kaique.xavieratalla)
-- [Twitter](@kaique_xavier)
+- [Twitter](https://twitter.com/kaique_xavier)
 - [LinkedIn](https://www.linkedin.com/in/kaique-atalla-3a1562125/)

--- a/profiles/pupils/profiles/LarissaMourullo.md
+++ b/profiles/pupils/profiles/LarissaMourullo.md
@@ -12,8 +12,8 @@ Atualmente quero continuar adquirindo conhecimento e aprender cada dia mais com 
 
 ## Alguns links para me conhecer melhor
 
-[WebSite](http://larismourullo.github.io)
-[Twitter](https://twitter.com/larismourullo)
-[GitHub](https://github.com/larismourullo)
-[Facebook](https://www.facebook.com/larissamourullo)
-[Linkedin](https://br.linkedin.com/in/larissa-mourullo-040073b9/)
+- [WebSite](http://larismourullo.github.io)
+- [Twitter](https://twitter.com/larismourullo)
+- [GitHub](https://github.com/larismourullo)
+- [Facebook](https://www.facebook.com/larissamourullo)
+- [Linkedin](https://br.linkedin.com/in/larissa-mourullo-040073b9/)

--- a/profiles/pupils/profiles/LeonanMachado.md
+++ b/profiles/pupils/profiles/LeonanMachado.md
@@ -12,7 +12,7 @@ Poder ajudar muito a comunidade com novos projetos e dar continuidade de projeto
 
 ## Alguns links para me conhecer melhor:
 
-- Email: leonantvrs@gmail.com
+- [Email](mailto:leonantvrs@gmail.com)
 - [Linkedin](https://www.linkedin.com/in/leonanmachado/)
 - [Github](https://github.com/leonantvrs)
 - [Twitter](https://twitter.com/leonantvrs)

--- a/profiles/pupils/profiles/LeonardoMaturano.md
+++ b/profiles/pupils/profiles/LeonardoMaturano.md
@@ -14,7 +14,7 @@ Aprimorar meus conhecimentos como Desenvolvedor Web, e poder contribuir com a co
 
 ## Alguns links para me conhecer melhor
 
-* [Facebook](https://www.facebook.com/leomaturano)
-* [LinkedIn](https://www.linkedin.com/in/leonardomaturano)
-* [GitHub](https://github.com/leomaturano)
-* [Twitter](https://twitter.com/leomaturano)
+- [Facebook](https://www.facebook.com/leomaturano)
+- [LinkedIn](https://www.linkedin.com/in/leonardomaturano)
+- [GitHub](https://github.com/leomaturano)
+- [Twitter](https://twitter.com/leomaturano)

--- a/profiles/pupils/profiles/LeonardoSousa.md
+++ b/profiles/pupils/profiles/LeonardoSousa.md
@@ -12,4 +12,4 @@ Conseguir um emprego como Backend e me aperfeiçoar cada vez mais na área.
 
 ## Alguns links para me conhecer melhor
 
-[GitHub](https://github.com/leonardolsousa)
+- [GitHub](https://github.com/leonardolsousa)

--- a/profiles/pupils/profiles/LeticiaCosta.md
+++ b/profiles/pupils/profiles/LeticiaCosta.md
@@ -12,6 +12,6 @@ Contribuir para um projeto inovador e impactante na vida de muitas pessoas
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/lecostadias)
+- [Facebook](https://www.facebook.com/lecostadias)
 
-[LinkedIn](https://www.linkedin.com/in/let%C3%ADcia-costa-94555052/)
+- [LinkedIn](https://www.linkedin.com/in/let%C3%ADcia-costa-94555052/)

--- a/profiles/pupils/profiles/LeticiaCosta.md
+++ b/profiles/pupils/profiles/LeticiaCosta.md
@@ -13,5 +13,4 @@ Contribuir para um projeto inovador e impactante na vida de muitas pessoas
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/lecostadias)
-
 - [LinkedIn](https://www.linkedin.com/in/let%C3%ADcia-costa-94555052/)

--- a/profiles/pupils/profiles/LucasAugusto.md
+++ b/profiles/pupils/profiles/LucasAugusto.md
@@ -9,8 +9,8 @@ Quero me tornar um Front End Engineer
 
 ## Alguns links para me conhecer melhor
 
-[Facebook Lucas Augusto](https://www.facebook.com/lucasaugustofrontend "Lucas Augusto")
+- [Facebook](https://www.facebook.com/lucasaugustofrontend "Lucas Augusto")
 
-[Twitter Lucas Augusto](https://twitter.com/laugustofront "Lucas Augusto")
+- [Twitter](https://twitter.com/laugustofront "Lucas Augusto")
 
-[LinkedIn Lucas Augusto](https://www.linkedin.com/in/laugustofrontend/ "Lucas Augusto")
+- [LinkedIn](https://www.linkedin.com/in/laugustofrontend/ "Lucas Augusto")

--- a/profiles/pupils/profiles/LucasAugusto.md
+++ b/profiles/pupils/profiles/LucasAugusto.md
@@ -2,15 +2,16 @@
 
 [Felipe Rank](https://github.com/training-center/mentoria/blob/master/profiles/mentors/profiles/felipe_rank.md)
 
-## Lucas Augusto
+## Meu Nome
+
+Lucas Augusto
 
 ## Qual meu sonho na carreira?
+
 Quero me tornar um Front End Engineer
 
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/lucasaugustofrontend "Lucas Augusto")
-
 - [Twitter](https://twitter.com/laugustofront "Lucas Augusto")
-
 - [LinkedIn](https://www.linkedin.com/in/laugustofrontend/ "Lucas Augusto")

--- a/profiles/pupils/profiles/LucasSales.md
+++ b/profiles/pupils/profiles/LucasSales.md
@@ -13,7 +13,7 @@ Lucas Sales
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://facebook.com/luvetica)
-[Twitter](https://twitter.com/luvetica)
-[LinkedIn](http://ow.ly/YvzC303qN9P)
+- [Facebook](https://facebook.com/luvetica)
+- [Twitter](https://twitter.com/luvetica)
+- [LinkedIn](http://ow.ly/YvzC303qN9P)
 

--- a/profiles/pupils/profiles/LucasSilva.md
+++ b/profiles/pupils/profiles/LucasSilva.md
@@ -12,4 +12,4 @@ Ser um desenvolvedor melhor, porém nunca deixar de me importar com UX, UI. Tamb
 
 ## Alguns links para me conhecer melhor
 
-* [Twitter](https://twitter.com/lucas_dejsilva)
+- [Twitter](https://twitter.com/lucas_dejsilva)

--- a/profiles/pupils/profiles/LuccasCandido.md
+++ b/profiles/pupils/profiles/LuccasCandido.md
@@ -12,4 +12,4 @@ Meu sonho de carreira é trabalhar com tecnologia, mas tenho um desejo enorme po
 
 ## Alguns links para me conhecer melhor
 
-[Twitter do Luccas Candido](http://twitter.com/luccasdebarros)  
+- [Twitter](http://twitter.com/luccasdebarros)  

--- a/profiles/pupils/profiles/LuizGlatz.md
+++ b/profiles/pupils/profiles/LuizGlatz.md
@@ -12,5 +12,5 @@ Quero poder trabalhar como desenvolvedor back-end.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/luiz.glatz.9) | 
-[LinkedIn](https://br.linkedin.com/in/luiz-glatz)
+- [Facebook](https://www.facebook.com/luiz.glatz.9) | 
+- [LinkedIn](https://br.linkedin.com/in/luiz-glatz)

--- a/profiles/pupils/profiles/LuizLazaro.md
+++ b/profiles/pupils/profiles/LuizLazaro.md
@@ -12,6 +12,6 @@ Me tornar um desenvolvedor apto para contribuir com projetos para a comunidade e
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](http://www.facebook.com/LajackBR)
-[Twitter](http://www.twitter.com/LajackBR)
-[Google+](https://plus.google.com/u/0/108706624896557923324)
+- [Facebook](http://www.facebook.com/LajackBR)
+- [Twitter](http://www.twitter.com/LajackBR)
+- [Google+](https://plus.google.com/u/0/108706624896557923324)

--- a/profiles/pupils/profiles/LuizLazaro.md
+++ b/profiles/pupils/profiles/LuizLazaro.md
@@ -6,7 +6,7 @@
 
 Luiz Lázaro
 
-##Qual meu sonho na carreira?
+## Qual meu sonho na carreira?
 
 Me tornar um desenvolvedor apto para contribuir com projetos para a comunidade e para a sociedade em geral de forma inteligível, me tornando assim uma referência na área.
 

--- a/profiles/pupils/profiles/MarceloHenrique.md
+++ b/profiles/pupils/profiles/MarceloHenrique.md
@@ -16,9 +16,8 @@ HTML, CSS, Javascript básico faço tutoriais mais quando é para fazer algo do 
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Marcelo Henrique](https://www.facebook.com/maassilva)
-[Twitter do Marcelo Henrique](https://twitter.com/marcelossilva)
-[LinkedIn do Pupilo de Castro](https://www.linkedin.com/in/cvmarcelosilva)
-[Github do Marcelo Henrique](https://github.com/Marcelosilva10)
-[Codepen do Marcelo Henrique](https://codepen.io/marcelossilva)
-```
+- [Facebook do Marcelo Henrique](https://www.facebook.com/maassilva)
+- [Twitter do Marcelo Henrique](https://twitter.com/marcelossilva)
+- [LinkedIn do Pupilo de Castro](https://www.linkedin.com/in/cvmarcelosilva)
+- [Github do Marcelo Henrique](https://github.com/Marcelosilva10)
+- [Codepen do Marcelo Henrique](https://codepen.io/marcelossilva)

--- a/profiles/pupils/profiles/MarcioAlves.md
+++ b/profiles/pupils/profiles/MarcioAlves.md
@@ -8,9 +8,8 @@ Marcio Alves
 ## Sobre mim
 ** Atualmente eu me encontro estudando, bom começo na Universidade semana que vem, como Análise e Desenvolvimento de Sistemas, amo Programação, passei a gostar de programação devido aos códigos, e de ver sites de outras empresas fora de padrão... Hoje eu tenho um conhecimento básico, em relação a área em si da Programação, adquirir este conhecimento através, de videos do youtube mesmo e alguns sites que ensinam, isso antes de eu decidir em querer a começar estudar Análise... Bom meu intuito aqui é tirar as minhas dúvidas com vocês, e aprendendo com vocês, estarei sempre grato em retribui-los o favor...
 
-
 ## Contatos
 
-- [E-mail](mailto:marciiosouza@outlook.com)
+- [Email](mailto:marciiosouza@outlook.com)
 - [Facebook](https://www.facebook.com/MarciioSouzah)
 - [Twitter](https://twitter.com/MarciioSouz)

--- a/profiles/pupils/profiles/MarcioAlves.md
+++ b/profiles/pupils/profiles/MarcioAlves.md
@@ -11,6 +11,6 @@ Marcio Alves
 
 ## Contatos
 
-[E-mail](mailto:marciiosouza@outlook.com)
-[Facebook](https://www.facebook.com/MarciioSouzah)
-[Twitter](https://twitter.com/MarciioSouz)
+- [E-mail](mailto:marciiosouza@outlook.com)
+- [Facebook](https://www.facebook.com/MarciioSouzah)
+- [Twitter](https://twitter.com/MarciioSouz)

--- a/profiles/pupils/profiles/MarianaRuther.md
+++ b/profiles/pupils/profiles/MarianaRuther.md
@@ -12,6 +12,6 @@ Aprender tudo que eu puder, me tornar uma desenvolvedora Full Stack e contribuir
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/mariana.ruther)
-[Twitter](https://twitter.com/mruther)
-[LinkedIn](https://www.linkedin.com/in/marianaruther/)
+- [Facebook](https://www.facebook.com/mariana.ruther)
+- [Twitter](https://twitter.com/mruther)
+- [LinkedIn](https://www.linkedin.com/in/marianaruther/)

--- a/profiles/pupils/profiles/MateusMedeiros.md
+++ b/profiles/pupils/profiles/MateusMedeiros.md
@@ -12,5 +12,5 @@ Quero conseguir um emprego como Desenvolvedor Front End e contribuir com a comun
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/mateussousam)
-[GitHub](https://github.com/mateussmedeiros)
+- [Twitter](https://twitter.com/mateussousam)
+- [GitHub](https://github.com/mateussmedeiros)

--- a/profiles/pupils/profiles/MatheusAraujo.md
+++ b/profiles/pupils/profiles/MatheusAraujo.md
@@ -10,5 +10,5 @@ Poder evoluir na minha carreira, adquirindo um novo conhecimento que é o desenv
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/matheus.araujo.77985)
+- [Facebook](https://www.facebook.com/matheus.araujo.77985)
 

--- a/profiles/pupils/profiles/MatheusSouza.md
+++ b/profiles/pupils/profiles/MatheusSouza.md
@@ -12,7 +12,7 @@ Me tornar um desenvolvedor back-end reconhecido, versátil e competente
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/mh.matheussouza)
-[Twitter](https://twitter.com/mh_matheussouza)
-[LinkedIn](https://www.linkedin.com/in/matheushsouza)
-[GitHub](https://www.github.com/matheus-souza)
+- [Facebook](https://www.facebook.com/mh.matheussouza)
+- [Twitter](https://twitter.com/mh_matheussouza)
+- [LinkedIn](https://www.linkedin.com/in/matheushsouza)
+- [GitHub](https://www.github.com/matheus-souza)

--- a/profiles/pupils/profiles/MaxwelFerreira.md
+++ b/profiles/pupils/profiles/MaxwelFerreira.md
@@ -12,5 +12,5 @@ Quero me tornar um desenvolvedor full stack e ajudar a comunidade.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/maxwel.ferreira.58)
-[Twitter](https://twitter.com/maxwelfe04)
+- [Facebook](https://www.facebook.com/maxwel.ferreira.58)
+- [Twitter](https://twitter.com/maxwelfe04)

--- a/profiles/pupils/profiles/MichelDias.md
+++ b/profiles/pupils/profiles/MichelDias.md
@@ -11,6 +11,6 @@ Michel Dias.
 Iniciar minha carreira na área de desenvolvimento.
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/michel.dias.96)
-[GitHub](https://github.com/micheldias)
-[LinkedIn](https://br.linkedin.com/in/michel-dias-24123530)
+- [Facebook](https://www.facebook.com/michel.dias.96)
+- [GitHub](https://github.com/micheldias)
+- [LinkedIn](https://br.linkedin.com/in/michel-dias-24123530)

--- a/profiles/pupils/profiles/MichelDias.md
+++ b/profiles/pupils/profiles/MichelDias.md
@@ -1,12 +1,12 @@
-#Mentor(a) responsável por mim
+# Mentor(a) responsável por mim
 
 Ainda não possuo.
 
-##Meu Nome
+## Meu Nome
 
 Michel Dias.
 
-##Qual meu sonho na carreira?
+## Qual meu sonho na carreira?
 
 Iniciar minha carreira na área de desenvolvimento.
 

--- a/profiles/pupils/profiles/MuriloMarchesi.md
+++ b/profiles/pupils/profiles/MuriloMarchesi.md
@@ -12,4 +12,4 @@ Me tornar um bom desenvolvedor !
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/murilo.marchesi)
+- [Facebook](https://www.facebook.com/murilo.marchesi)

--- a/profiles/pupils/profiles/NikolasBrandao.md
+++ b/profiles/pupils/profiles/NikolasBrandao.md
@@ -18,6 +18,4 @@ Dominio basico do inglês e francês.
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/NikolasBrandao)
-
-
 - [Twitter](https://twitter.com/ofabricante)

--- a/profiles/pupils/profiles/NikolasBrandao.md
+++ b/profiles/pupils/profiles/NikolasBrandao.md
@@ -17,7 +17,7 @@ Dominio basico do inglês e francês.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/NikolasBrandao)
+- [Facebook](https://www.facebook.com/NikolasBrandao)
 
 
-[Twitter](https://twitter.com/ofabricante)
+- [Twitter](https://twitter.com/ofabricante)

--- a/profiles/pupils/profiles/OsmarVillalba.md
+++ b/profiles/pupils/profiles/OsmarVillalba.md
@@ -19,6 +19,5 @@ Dominio basico do inglês e portugues, meu idioma oficial e Espanhol
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/osmar.luc)
-
 - [Twitter](https://twitter.com/osmar_luc)
 

--- a/profiles/pupils/profiles/OsmarVillalba.md
+++ b/profiles/pupils/profiles/OsmarVillalba.md
@@ -18,7 +18,7 @@ Dominio basico do inglês e portugues, meu idioma oficial e Espanhol
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/osmar.luc)
+- [Facebook](https://www.facebook.com/osmar.luc)
 
-[Twitter](https://twitter.com/osmar_luc)
+- [Twitter](https://twitter.com/osmar_luc)
 

--- a/profiles/pupils/profiles/PedroGermano.md
+++ b/profiles/pupils/profiles/PedroGermano.md
@@ -11,6 +11,6 @@ Espero um dia trabalhar para uma empresa com grandes projetos, Quero me aperfei√
 
 ## Alguns links para me conhecer melhor
 
-- [Facebook](https://www.facebook.com/pedrogermano232)<br/>
-- [Twitter](https://twitter.com/PedroGermano6)<br/>
+- [Facebook](https://www.facebook.com/pedrogermano232)
+- [Twitter](https://twitter.com/PedroGermano6)
 - [GitHub](https://github.com/pedroGermano)

--- a/profiles/pupils/profiles/PedroGermano.md
+++ b/profiles/pupils/profiles/PedroGermano.md
@@ -11,6 +11,6 @@ Espero um dia trabalhar para uma empresa com grandes projetos, Quero me aperfei√
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Pedro Germano](https://www.facebook.com/pedrogermano232)<br/>
-[Twitter do Pedro Germano](https://twitter.com/PedroGermano6)<br/>
-[GitHub do Pedro Germano](https://github.com/pedroGermano)
+- [Facebook](https://www.facebook.com/pedrogermano232)<br/>
+- [Twitter](https://twitter.com/PedroGermano6)<br/>
+- [GitHub](https://github.com/pedroGermano)

--- a/profiles/pupils/profiles/PedroLeao.md
+++ b/profiles/pupils/profiles/PedroLeao.md
@@ -12,6 +12,6 @@ Ser capaz de transformar ideias que possam melhorar nossa sociedade em realidade
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/phenriqueleao)
-[Twitter](https://www.twitter.com/phenriqueleao)
-[LinkedIn](https://br.linkedin.com/in/pedro-henrique-le%C3%A3o-97b10052?trk=prof-samename-name)
+- [Facebook](https://www.facebook.com/phenriqueleao)
+- [Twitter](https://www.twitter.com/phenriqueleao)
+- [LinkedIn](https://br.linkedin.com/in/pedro-henrique-le%C3%A3o-97b10052?trk=prof-samename-name)

--- a/profiles/pupils/profiles/PedroLeao.md
+++ b/profiles/pupils/profiles/PedroLeao.md
@@ -14,4 +14,4 @@ Ser capaz de transformar ideias que possam melhorar nossa sociedade em realidade
 
 - [Facebook](https://www.facebook.com/phenriqueleao)
 - [Twitter](https://www.twitter.com/phenriqueleao)
-- [LinkedIn](https://br.linkedin.com/in/pedro-henrique-le%C3%A3o-97b10052?trk=prof-samename-name)
+- [LinkedIn](https://br.linkedin.com/in/pedro-henrique-le%C3%A3o-97b10052)

--- a/profiles/pupils/profiles/RafaelCavalcanti.md
+++ b/profiles/pupils/profiles/RafaelCavalcanti.md
@@ -12,6 +12,6 @@ Quero aprender desenvolvimento Full-Stack para contribuir com a comunidade e pod
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://facebook.com/rafael.g.cavalcanti)  
-[Twitter](https://twitter.com/meli_dev)  
-[LinkedIn](https://www.linkedin.com/in/rafael-gomes-cavalcanti-1226b5b8?trk=nav_responsive_tab_profile)
+- [Facebook](https://facebook.com/rafael.g.cavalcanti)  
+- [Twitter](https://twitter.com/meli_dev)  
+- [LinkedIn](https://www.linkedin.com/in/rafael-gomes-cavalcanti-1226b5b8?trk=nav_responsive_tab_profile)

--- a/profiles/pupils/profiles/RafaelCavalcanti.md
+++ b/profiles/pupils/profiles/RafaelCavalcanti.md
@@ -14,4 +14,4 @@ Quero aprender desenvolvimento Full-Stack para contribuir com a comunidade e pod
 
 - [Facebook](https://facebook.com/rafael.g.cavalcanti)  
 - [Twitter](https://twitter.com/meli_dev)  
-- [LinkedIn](https://www.linkedin.com/in/rafael-gomes-cavalcanti-1226b5b8?trk=nav_responsive_tab_profile)
+- [LinkedIn](https://www.linkedin.com/in/rafael-gomes-cavalcanti-1226b5b8)

--- a/profiles/pupils/profiles/RafaelSantana.md
+++ b/profiles/pupils/profiles/RafaelSantana.md
@@ -13,5 +13,5 @@ para que um dia eu possa ter destaque suficiente para trabalhar fora do país.
 
 ## Alguns links para me conhecer melhor
 
-[Meu Linkedln](https://www.linkedin.com/in/rafasantana/)
-[Meu Github](https://github.com/RafaSantana)
+- [Linkedln](https://www.linkedin.com/in/rafasantana/)
+- [Github](https://github.com/RafaSantana)

--- a/profiles/pupils/profiles/RafaelVianna.md
+++ b/profiles/pupils/profiles/RafaelVianna.md
@@ -13,4 +13,4 @@ Me aperfeiçoar como desenvolvedor front end, e futuramente me tornar fullstack
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/rafael.ferreira.1806)
-- [LinkedIn](https://www.linkedin.com/in/rafael-ferreira-52009996?trk=nav_responsive_tab_profile)
+- [LinkedIn](https://www.linkedin.com/in/rafael-ferreira-52009996)

--- a/profiles/pupils/profiles/RafaelVianna.md
+++ b/profiles/pupils/profiles/RafaelVianna.md
@@ -12,5 +12,5 @@ Me aperfeiçoar como desenvolvedor front end, e futuramente me tornar fullstack
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/rafael.ferreira.1806)
-[LinkedIn](https://www.linkedin.com/in/rafael-ferreira-52009996?trk=nav_responsive_tab_profile)
+- [Facebook](https://www.facebook.com/rafael.ferreira.1806)
+- [LinkedIn](https://www.linkedin.com/in/rafael-ferreira-52009996?trk=nav_responsive_tab_profile)

--- a/profiles/pupils/profiles/Rafaela_Cassiano_Campos.md
+++ b/profiles/pupils/profiles/Rafaela_Cassiano_Campos.md
@@ -1,16 +1,16 @@
-<h1>Mentor Responsável por mim:</h1>
+# Mentor(a) responsável por mim:
 
-<a href="https://github.com/RafaelaCassianoCampos/mentoria/blob/master/profiles/mentors/profiles/felipe_rank.md">Felipe Rank</a>
+[Felipe Rank](https://github.com/training-center/mentoria/blob/master/profiles/mentors/profiles/felipe_rank.md)
 
-<h1>Meu Nome:</h1>
+## Meu Nome:
 
-<a href="https://github.com/RafaelaCassianoCampos">Rafaela Cassiano Campos</a>
+Rafaela Cassiano Campos
 
-<h1>Qual o meu sonho na carreira?</h1>
+## Qual o meu sonho na carreira?
 
-<p>Meu sonho é trabalhar como Back End ou FullStack no exterior, principalmente no Canadá. Com isso, ter uma carreira bem sucedida, na qual eu me orgulhe e supere minhas limitações e desafios, de tal forma que me mantenha num processo de constante aprendizagem. Além disso, também gostaria de poder repassar meus conhecimentos aos outros futuramente também pela mentoria, porque acredito que isso seja necessário para um mundo melhor e que juntos podemos fazer mais!</p>
+Meu sonho é trabalhar como Back End ou FullStack no exterior, principalmente no Canadá. Com isso, ter uma carreira bem sucedida, na qual eu me orgulhe e supere minhas limitações e desafios, de tal forma que me mantenha num processo de constante aprendizagem. Além disso, também gostaria de poder repassar meus conhecimentos aos outros futuramente também pela mentoria, porque acredito que isso seja necessário para um mundo melhor e que juntos podemos fazer mais!
 
-<h1>Links para me conhecer melhor</h1>
-<ul>
-<li><a href="https://www.linkedin.com/in/rafaela-cassiano-campos-466b51147/">LinkedIn</a><br/></li>
-<li><a href="https://www.facebook.com/rafaela.campos.106/">Facebook</a></li>
+## Alguns links para me conhecer melhor:
+
+- [LinkedIn](https://www.linkedin.com/in/rafaela-cassiano-campos-466b51147/)
+- [Facebook](http://www.facebook.com/rafaela.campos.106/)

--- a/profiles/pupils/profiles/RamonFrancisco.md
+++ b/profiles/pupils/profiles/RamonFrancisco.md
@@ -14,4 +14,4 @@ Me torna uma referência na comunidade, e contribuir para que outros devs possam
 
 - [Facebook](https://www.facebook.com/ramon.francisco.901)
 - [Twitter](https://twitter.com/FrontEndRamon)
-- [LinkedIn](https://www.linkedin.com/in/ramon-f-354340125?trk=nav_responsive_tab_profile_pic)
+- [LinkedIn](https://www.linkedin.com/in/ramon-f-354340125)

--- a/profiles/pupils/profiles/RamonFrancisco.md
+++ b/profiles/pupils/profiles/RamonFrancisco.md
@@ -12,6 +12,6 @@ Me torna uma referência na comunidade, e contribuir para que outros devs possam
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/ramon.francisco.901)
-[Twitter](https://twitter.com/FrontEndRamon)
-[LinkedIn](https://www.linkedin.com/in/ramon-f-354340125?trk=nav_responsive_tab_profile_pic)
+- [Facebook](https://www.facebook.com/ramon.francisco.901)
+- [Twitter](https://twitter.com/FrontEndRamon)
+- [LinkedIn](https://www.linkedin.com/in/ramon-f-354340125?trk=nav_responsive_tab_profile_pic)

--- a/profiles/pupils/profiles/RenanMoura.md
+++ b/profiles/pupils/profiles/RenanMoura.md
@@ -10,6 +10,6 @@ Fazer com que o desenvolvimento de softwares e afins possa me garantir conhecer 
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/renan.silva.moura)
-[Linkedin](https://br.linkedin.com/in/renansmoura)
-[GitHub](https://github.com/RenanSMoura)
+- [Facebook](https://www.facebook.com/renan.silva.moura)
+- [Linkedin](https://br.linkedin.com/in/renansmoura)
+- [GitHub](https://github.com/RenanSMoura)

--- a/profiles/pupils/profiles/RodrigoGarcia.md
+++ b/profiles/pupils/profiles/RodrigoGarcia.md
@@ -10,16 +10,14 @@ Rodrigo Garcia Hernandez
 
 Quero poder criar uma nova perspectiva do desenvolvimento Web, aprender, melhorar e poder algum dia incentivar as demais pessoas neste mundo incrível.
 
-#Conhecimentos
+# Conhecimentos
+
 Tenho conhecimientos basicos de linguagem como HTML, CSS, JavaScript, PHP. mas considero que meus cohecimientos ainda são muito fracos e por isso fico sempre com muita vontade de aprender. 
 Atualmente estou fazendo estagio na Pipefy uma das melhores startups não só do Brasil ao lado do meu mentor Fernado Moreira e sem duvidas sei que pronto através deste programa de mentorias vou poder ser um master no desenvolvimiento Web.  
 
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/rodrigo.garciahern)
-
 - [Twitter](https://twitter.com/Im_rodrigho)
-
 - [LinkedIn](https://www.linkedin.com/in/rodrigogarciahernandez)
-
 - [GitHub](https://github.com/rodrigogarh)

--- a/profiles/pupils/profiles/RodrigoGarcia.md
+++ b/profiles/pupils/profiles/RodrigoGarcia.md
@@ -10,7 +10,7 @@ Rodrigo Garcia Hernandez
 
 Quero poder criar uma nova perspectiva do desenvolvimento Web, aprender, melhorar e poder algum dia incentivar as demais pessoas neste mundo incrível.
 
-# Conhecimentos
+## Conhecimentos
 
 Tenho conhecimientos basicos de linguagem como HTML, CSS, JavaScript, PHP. mas considero que meus cohecimientos ainda são muito fracos e por isso fico sempre com muita vontade de aprender. 
 Atualmente estou fazendo estagio na Pipefy uma das melhores startups não só do Brasil ao lado do meu mentor Fernado Moreira e sem duvidas sei que pronto através deste programa de mentorias vou poder ser um master no desenvolvimiento Web.  

--- a/profiles/pupils/profiles/RodrigoGarcia.md
+++ b/profiles/pupils/profiles/RodrigoGarcia.md
@@ -16,10 +16,10 @@ Atualmente estou fazendo estagio na Pipefy uma das melhores startups não só do
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Rodrigo Garcia](https://www.facebook.com/rodrigo.garciahern)
+- [Facebook](https://www.facebook.com/rodrigo.garciahern)
 
-[Twitter do Rodrigo Garcia](https://twitter.com/Im_rodrigho)
+- [Twitter](https://twitter.com/Im_rodrigho)
 
-[LinkedIn do Rodrigo Garcia](https://www.linkedin.com/in/rodrigogarciahernandez)
+- [LinkedIn](https://www.linkedin.com/in/rodrigogarciahernandez)
 
-[GitHub do Rodrigo Garcia](https://github.com/rodrigogarh)
+- [GitHub](https://github.com/rodrigogarh)

--- a/profiles/pupils/profiles/RodrigoPontes.md
+++ b/profiles/pupils/profiles/RodrigoPontes.md
@@ -12,5 +12,5 @@ Ser bem-sucedido como front-end dev depois de uma mudança (tardia) de carreira.
 
 ## Alguns links para me conhecer melhor
 
-[LinkedIn](https://br.linkedin.com/in/rodrigohgpontes)
-[Twitter](twitter.com/sousoneca)
+- [LinkedIn](https://br.linkedin.com/in/rodrigohgpontes)
+- [Twitter](twitter.com/sousoneca)

--- a/profiles/pupils/profiles/RogerioMoura.md
+++ b/profiles/pupils/profiles/RogerioMoura.md
@@ -12,5 +12,6 @@ Compartilho também o sonho de poder adquirir um nível de conhecimento o qual p
 Tenho conhecimentos básicos/intermediários de linguagens como HTML, CSS, JavaScript, PHP, C#, e de alguns frameworks das mesmas.
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/rogerio.moura3)
-[LinkedIn](https://www.linkedin.com/in/rogerio-moura-6a65548b)
+
+- [Facebook](https://www.facebook.com/rogerio.moura3)
+- [LinkedIn](https://www.linkedin.com/in/rogerio-moura-6a65548b)

--- a/profiles/pupils/profiles/RogerioMoura.md
+++ b/profiles/pupils/profiles/RogerioMoura.md
@@ -8,7 +8,7 @@ Rogerio Faria Moura
 Meu sonho consiste em conhecimentos. Conseguir adquirir e entender o máximo possível sobre as linguagens, tanto front end quanto back end, e um dia quem sabe desenvolver uma aplicação que seja capaz de ajudar a galera com suas necessidades.
 Compartilho também o sonho de poder adquirir um nível de conhecimento o qual posso repassar e ser útil para outras pessoas que futuramente estarão como eu estou agora :)
 
-#Conhecimentos
+## Conhecimentos
 Tenho conhecimentos básicos/intermediários de linguagens como HTML, CSS, JavaScript, PHP, C#, e de alguns frameworks das mesmas.
 
 ## Alguns links para me conhecer melhor

--- a/profiles/pupils/profiles/RomarioCoimbra.md
+++ b/profiles/pupils/profiles/RomarioCoimbra.md
@@ -11,4 +11,5 @@ Iniciar minha carreira como desenvolvedor Front-end e aprofundar meus estudos pa
 Como desenvolvedor Front-end tenho conhecimento nas tecnologias HTML, CSS, JavaScript, Bootstrap, Gulp.
 
 ## Alguns links para me conhecer melhor
-[facebook](https://www.facebook.com/romarioccoimbra)
+
+- [Facebook](https://www.facebook.com/romarioccoimbra)

--- a/profiles/pupils/profiles/RomarioCoimbra.md
+++ b/profiles/pupils/profiles/RomarioCoimbra.md
@@ -7,7 +7,7 @@ Romário Coimbra
 ## Qual meu sonho na carreira?
 Iniciar minha carreira como desenvolvedor Front-end e aprofundar meus estudos para uma futura carreira como full-stack.
 
-#Conhecimentos
+## Conhecimentos
 Como desenvolvedor Front-end tenho conhecimento nas tecnologias HTML, CSS, JavaScript, Bootstrap, Gulp.
 
 ## Alguns links para me conhecer melhor

--- a/profiles/pupils/profiles/SafireLauene.md
+++ b/profiles/pupils/profiles/SafireLauene.md
@@ -8,6 +8,7 @@ Safire Lauene
 Tenho o sonho de adquirir conhecimentos sólidos o bastante para me sentir confiante em compartilhá-los com outras pessoas. :blush:
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/safire.lauene)
-[Twitter](https://twitter.com/Firelauene)
-[LinkedIn](https://br.linkedin.com/in/safire-lauene-a54588a0)
+
+- [Facebook](https://www.facebook.com/safire.lauene)
+- [Twitter](https://twitter.com/Firelauene)
+- [LinkedIn](https://br.linkedin.com/in/safire-lauene-a54588a0)

--- a/profiles/pupils/profiles/SofiaBareta.md
+++ b/profiles/pupils/profiles/SofiaBareta.md
@@ -14,5 +14,4 @@ Ser ninja no front-end, manjar de UX e me virar bem no back-end :)
 ## Alguns links para me conhecer melhor:
 
 - [Facebook](https://www.facebook.com/sofibareta)
-
 - [Github](https://github.com/sofiabareta)

--- a/profiles/pupils/profiles/SofiaBareta.md
+++ b/profiles/pupils/profiles/SofiaBareta.md
@@ -13,6 +13,6 @@ Ser ninja no front-end, manjar de UX e me virar bem no back-end :)
 
 ## Alguns links para me conhecer melhor:
 
-[Facebook](https://www.facebook.com/sofibareta)
+- [Facebook](https://www.facebook.com/sofibareta)
 
-[Github](https://github.com/sofiabareta)
+- [Github](https://github.com/sofiabareta)

--- a/profiles/pupils/profiles/SofiaBareta.md
+++ b/profiles/pupils/profiles/SofiaBareta.md
@@ -10,7 +10,6 @@ Sofia Bareta
 
 Ser ninja no front-end, manjar de UX e me virar bem no back-end :)
 
-
 ## Alguns links para me conhecer melhor:
 
 - [Facebook](https://www.facebook.com/sofibareta)

--- a/profiles/pupils/profiles/Stoque.md
+++ b/profiles/pupils/profiles/Stoque.md
@@ -12,4 +12,4 @@ Me tornar uma referência na área de front end, criar/particiar de grandes proj
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/ostoque)
+- [Twitter](https://twitter.com/ostoque)

--- a/profiles/pupils/profiles/ThiagoMorasticoCruz.md
+++ b/profiles/pupils/profiles/ThiagoMorasticoCruz.md
@@ -13,5 +13,5 @@ me tornar um fullstack
 
 ## Alguns links para me conhecer melhor:
 
-[Facebook](http://www.facebook.com/thiago.morasticocruz)
-[LinkedIn](https://br.linkedin.com/in/thiago-morástico-cruz-3bb14666)
+- [Facebook](http://www.facebook.com/thiago.morasticocruz)
+- [LinkedIn](https://br.linkedin.com/in/thiago-morástico-cruz-3bb14666)

--- a/profiles/pupils/profiles/ThiagoPhillip.md
+++ b/profiles/pupils/profiles/ThiagoPhillip.md
@@ -13,6 +13,6 @@ Ser um bom programador, respeitando as boas práticas. Sempre estudar e contribu
 
 ## Alguns links para me conhecer melhor
 
-* [Facebook](https://www.facebook.com/thiagophrj)
-* [LinkedIn](https://www.linkedin.com/in/thiago-phillip-barbosa-05b07382)
-* [GitHub](https://github.com/philliprj)
+- [Facebook](https://www.facebook.com/thiagophrj)
+- [LinkedIn](https://www.linkedin.com/in/thiago-phillip-barbosa-05b07382)
+- [GitHub](https://github.com/philliprj)

--- a/profiles/pupils/profiles/TiagoFuelber.md
+++ b/profiles/pupils/profiles/TiagoFuelber.md
@@ -13,6 +13,6 @@ Tiago Saft Fuelber
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/tiago.fuelber)
-[Twitter](https://twitter.com/TiagoSaft)
-[LinkedIn](https://br.linkedin.com/in/tiagofuelber)
+- [Facebook](https://www.facebook.com/tiago.fuelber)
+- [Twitter](https://twitter.com/TiagoSaft)
+- [LinkedIn](https://br.linkedin.com/in/tiagofuelber)

--- a/profiles/pupils/profiles/VictorGrossi.md
+++ b/profiles/pupils/profiles/VictorGrossi.md
@@ -12,4 +12,4 @@ Aprender e contribuir.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/victor.grossi.14)
+- [Facebook](https://www.facebook.com/victor.grossi.14)

--- a/profiles/pupils/profiles/VictorMaciel.md
+++ b/profiles/pupils/profiles/VictorMaciel.md
@@ -14,3 +14,6 @@ Migrar para área de desenvolvimento e futuramente morar no exterior e viver de 
 
 facebook.com/vmaciell07
 twitter.com/vmaciel7
+
+- [Facebook](https://facebook.com/vmaciell07)
+- [Twitter](https://twitter.com/vmaciel7)

--- a/profiles/pupils/profiles/VictorPragana.md
+++ b/profiles/pupils/profiles/VictorPragana.md
@@ -13,8 +13,8 @@ Participar mais de eventos e comunidade.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](facebook.com/victorcesarmeriguepragana)
+- [Facebook](facebook.com/victorcesarmeriguepragana)
 
-[Twitter](https://twitter.com/victoorceesaar)
+- [Twitter](https://twitter.com/victoorceesaar)
 
-[LinkedIn](https://www.linkedin.com/in/victor-césar-merigue-pragana-689b2392)
+- [LinkedIn](https://www.linkedin.com/in/victor-césar-merigue-pragana-689b2392)

--- a/profiles/pupils/profiles/ViniciusAzevedo.md
+++ b/profiles/pupils/profiles/ViniciusAzevedo.md
@@ -22,5 +22,5 @@ Resumo da ópera: me estabilizar profissionalmente/financeiramente e ter o praze
 -  [Facebook](https://www.facebook.com/vinicius.azevedo.775)
 -  [Medium](https://medium.com/@viniazvd/)
 -  [LinkedIn](https://www.linkedin.com/in/vinicius-azevedo-a5a226100/)
--  [Github ](https://github.com/viniazvd)
+-  [Github](https://github.com/viniazvd)
 

--- a/profiles/pupils/profiles/VitorFerraz.md
+++ b/profiles/pupils/profiles/VitorFerraz.md
@@ -12,7 +12,7 @@ Quero me aperfeiçoar tecnicamente e seguir carreira como desenvolvedor web.
 Estou em uma fase de transição da área de gerenciamento de projetos para a de desenvolvimento, e gostaria de orientação para poder me tornar um profissional completo baseado na experiencia de programadores mais experientes.
 
 
-#Conhecimentos
+## Conhecimentos
 
 Tenho conhecimento de algumas linguagens como Java, JavaEE e C# na parte de back-end e html5,css3,javascript (ES6) , jQuery, Bootstrap e React na parte do front. Já fiz alguns cursos de programação além de estudar muito por fora. 
 
@@ -26,7 +26,7 @@ Estou aberto para qualquer esclarecimento e duvidas.
 
 ## Alguns links para me conhecer melhor
 
-- [Facebook](https://facebook.com/varelavf)<br/>
-- [Codepen](http://codepen.io/Vitor_Ferraz/)<br/>
-- [LinkedIn](https://br.linkedin.com/in/vitor-ferraz-ba143466)<br/>
-- [GitHub](https://github.com/VitorFerraz)<br/>
+- [Facebook](https://facebook.com/varelavf)
+- [Codepen](http://codepen.io/Vitor_Ferraz/)
+- [LinkedIn](https://br.linkedin.com/in/vitor-ferraz-ba143466)
+- [GitHub](https://github.com/VitorFerraz)

--- a/profiles/pupils/profiles/VitorFerraz.md
+++ b/profiles/pupils/profiles/VitorFerraz.md
@@ -26,7 +26,7 @@ Estou aberto para qualquer esclarecimento e duvidas.
 
 ## Alguns links para me conhecer melhor
 
-[Meu Facebook](https://facebook.com/varelavf)<br/>
-[Perfil do Codepen](http://codepen.io/Vitor_Ferraz/)<br/>
-[Meu LinkedIn](https://br.linkedin.com/in/vitor-ferraz-ba143466)<br/>
-[Meu GitHub](https://github.com/VitorFerraz)<br/>
+- [Facebook](https://facebook.com/varelavf)<br/>
+- [Codepen](http://codepen.io/Vitor_Ferraz/)<br/>
+- [LinkedIn](https://br.linkedin.com/in/vitor-ferraz-ba143466)<br/>
+- [GitHub](https://github.com/VitorFerraz)<br/>

--- a/profiles/pupils/profiles/WaldreySouzaSilva.md
+++ b/profiles/pupils/profiles/WaldreySouzaSilva.md
@@ -16,4 +16,4 @@ Front-end, Back-end. Atualmente estou me formando em Ciência da Computação e 
 - [Facebook](fb.com/waldrey)
 - [Twitter](https://twitter.com/waldreys)
 - [LinkedIn](https://www.linkedin.com/in/waldrey/)
-- [waldreysouzasilva@outlook.com](waldreysouzasilva@outlook.com)
+- [Email](mailto:waldreysouzasilva@outlook.com)

--- a/profiles/pupils/profiles/WashingtonOliveira.md
+++ b/profiles/pupils/profiles/WashingtonOliveira.md
@@ -12,6 +12,5 @@ Ser um bom desenvolvedor beck-end e trabalhar  na área como contratado ou free 
 
 ## Alguns links para me conhecer melhor:
 
-
-[Facebook](https://www.facebook.com/wwgtoliveira)
-[Github](https://github.com/wgtoliveira)
+- [Facebook](https://www.facebook.com/wwgtoliveira)
+- [Github](https://github.com/wgtoliveira)

--- a/profiles/pupils/profiles/WilliamCorrea.md
+++ b/profiles/pupils/profiles/WilliamCorrea.md
@@ -19,8 +19,8 @@ William Correa
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do William Correa](https://www.facebook.com/wilcorrea.site)
+- [Facebook](https://www.facebook.com/wilcorrea.site)
 
-[Twitter do William Correa](https://twitter.com/wilcorrea)
+- [Twitter](https://twitter.com/wilcorrea)
 
-[GitHub do William Correa](https://github.com/wilcorrea)
+- [GitHub](https://github.com/wilcorrea)

--- a/profiles/pupils/profiles/WilliamCorrea.md
+++ b/profiles/pupils/profiles/WilliamCorrea.md
@@ -20,7 +20,5 @@ William Correa
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/wilcorrea.site)
-
 - [Twitter](https://twitter.com/wilcorrea)
-
 - [GitHub](https://github.com/wilcorrea)

--- a/profiles/pupils/profiles/WilliamMeneses.md
+++ b/profiles/pupils/profiles/WilliamMeneses.md
@@ -15,7 +15,5 @@ William Meneses
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/williameneses)
-
 - [Twitter](https://twitter.com/JwilliamAnjos)
-
 - [GitHub](https://github.com/WilliamMeneses)

--- a/profiles/pupils/profiles/WilliamMeneses.md
+++ b/profiles/pupils/profiles/WilliamMeneses.md
@@ -14,8 +14,8 @@ William Meneses
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do William Meneses](https://www.facebook.com/williameneses)
+- [Facebook](https://www.facebook.com/williameneses)
 
-[Twitter do William Meneses](https://twitter.com/JwilliamAnjos)
+- [Twitter](https://twitter.com/JwilliamAnjos)
 
-[GitHub do William Meneses](https://github.com/WilliamMeneses)
+- [GitHub](https://github.com/WilliamMeneses)

--- a/profiles/pupils/profiles/YuriBrunetto.md
+++ b/profiles/pupils/profiles/YuriBrunetto.md
@@ -8,6 +8,7 @@ Yuri Brunetto
 Primeiramente conseguir um emprego em alguma start-up ou trabalhar com produto. Depois, morar fora do país sendo front-end developer. :+1:
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/brunettoyuri)
-[Twitter](https://twitter.com/yuribrunetto)
-[LinkedIn](https://br.linkedin.com/in/yuri-brunetto-3b8625a6)
+
+- [Facebook](https://www.facebook.com/brunettoyuri)
+- [Twitter](https://twitter.com/yuribrunetto)
+- [LinkedIn](https://br.linkedin.com/in/yuri-brunetto-3b8625a6)

--- a/profiles/pupils/profiles/Zanelatti.md
+++ b/profiles/pupils/profiles/Zanelatti.md
@@ -14,5 +14,5 @@ Concretizando esses eu sonho mais um pouco :)
 ## Alguns links para me conhecer melhor
 
 - [Facebook](http://www.facebook.com/diego.zanelatti)
-- [E-mail](diegozanelatti@hotmail.com)
+- [Email](mailto:diegozanelatti@hotmail.com)
 - [LinkedIn](https://www.linkedin.com/in/diego-zanelatti-21501a100?trk=nav_responsive_tab_profile)

--- a/profiles/pupils/profiles/Zanelatti.md
+++ b/profiles/pupils/profiles/Zanelatti.md
@@ -13,6 +13,6 @@ Concretizando esses eu sonho mais um pouco :)
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Diego Zanelatti](http://www.facebook.com/diego.zanelatti)
-[E-mail do Diego Zanelatti](diegozanelatti@hotmail.com)
-[LinkedIn do Diego Zanelatti](https://www.linkedin.com/in/diego-zanelatti-21501a100?trk=nav_responsive_tab_profile)
+- [Facebook](http://www.facebook.com/diego.zanelatti)
+- [E-mail](diegozanelatti@hotmail.com)
+- [LinkedIn](https://www.linkedin.com/in/diego-zanelatti-21501a100?trk=nav_responsive_tab_profile)

--- a/profiles/pupils/profiles/allysonthales.md
+++ b/profiles/pupils/profiles/allysonthales.md
@@ -11,8 +11,8 @@ Ainda sou apenas um estudante que tem diversos sonhos e expectativas profissiona
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/allyson.thales)
+- [Facebook](https://www.facebook.com/allyson.thales)
 
-[Twitter](https://twitter.com/alls_thales)
+- [Twitter](https://twitter.com/alls_thales)
 
-[LinkedIn](https://www.linkedin.com/in/allyson-thales/)
+- [LinkedIn](https://www.linkedin.com/in/allyson-thales/)

--- a/profiles/pupils/profiles/allysonthales.md
+++ b/profiles/pupils/profiles/allysonthales.md
@@ -5,6 +5,7 @@
 ## Meu Nome
 
 Allyson Thales dos Santos
+
 ## Qual meu sonho na carreira?
 
 Ainda sou apenas um estudante que tem diversos sonhos e expectativas profissionais, mas me encontro perdido com tantas possibilidades oferecidas no mundo de TI.
@@ -12,7 +13,5 @@ Ainda sou apenas um estudante que tem diversos sonhos e expectativas profissiona
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/allyson.thales)
-
 - [Twitter](https://twitter.com/alls_thales)
-
 - [LinkedIn](https://www.linkedin.com/in/allyson-thales/)

--- a/profiles/pupils/profiles/atreyucore.md
+++ b/profiles/pupils/profiles/atreyucore.md
@@ -12,5 +12,5 @@ Quero ser um ótimo profissional front-end
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/atreyu.maicon)
-[LinkedIn](https://www.linkedin.com/in/mrgomes86)
+- [Facebook](https://www.facebook.com/atreyu.maicon)
+- [LinkedIn](https://www.linkedin.com/in/mrgomes86)

--- a/profiles/pupils/profiles/caio.md
+++ b/profiles/pupils/profiles/caio.md
@@ -16,7 +16,5 @@ Conheço pouco sobre as linguagens, porém tenho facilidade de aprender, meu foc
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/kaioflavioo)
-
 - [Twitter](https://twitter.com/kaioflavio123)
-
 - [GitHub](https://github.com/CaioFlavio)

--- a/profiles/pupils/profiles/caio.md
+++ b/profiles/pupils/profiles/caio.md
@@ -10,7 +10,8 @@ Caio Flávio
 
 Meu sonho é criar algo de útil, utilizando os conhecimentos de programação e matemática.
 
-#Conhecimentos
+## Conhecimentos
+
 Conheço pouco sobre as linguagens, porém tenho facilidade de aprender, meu foco tem sido PHP devido ao trabalho que estou realizando.
 
 ## Alguns links para me conhecer melhor

--- a/profiles/pupils/profiles/caio.md
+++ b/profiles/pupils/profiles/caio.md
@@ -15,8 +15,8 @@ Conheço pouco sobre as linguagens, porém tenho facilidade de aprender, meu foc
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Caio FLavio](https://www.facebook.com/kaioflavioo)
+- [Facebook](https://www.facebook.com/kaioflavioo)
 
-[Twitter do Caio FLavio](https://twitter.com/kaioflavio123)
+- [Twitter](https://twitter.com/kaioflavio123)
 
-[GitHub do Caio FLavio](https://github.com/CaioFlavio)
+- [GitHub](https://github.com/CaioFlavio)

--- a/profiles/pupils/profiles/carlos-proenca.md
+++ b/profiles/pupils/profiles/carlos-proenca.md
@@ -12,5 +12,5 @@ Quero expandir meus conhecimentos em DEV crescendo cada vez mais na carreira e q
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/proencasilva)
-[LinkedIn](https://www.linkedin.com/in/carlos-eduardo-proen%C3%A7a-silva-ab628b26/)
+- [Facebook](https://www.facebook.com/proencasilva)
+- [LinkedIn](https://www.linkedin.com/in/carlos-eduardo-proen%C3%A7a-silva-ab628b26/)

--- a/profiles/pupils/profiles/danielneri.md
+++ b/profiles/pupils/profiles/danielneri.md
@@ -13,4 +13,4 @@ Evoluir sempre e me tornar um grande profissional.
 ## Alguns links para me conhecer melhor
 
 
-[Twitter do Daniel Neri](http://twitter.com/nedango)
+- [Twitter](http://twitter.com/nedango)

--- a/profiles/pupils/profiles/danielneri.md
+++ b/profiles/pupils/profiles/danielneri.md
@@ -12,5 +12,4 @@ Evoluir sempre e me tornar um grande profissional.
 
 ## Alguns links para me conhecer melhor
 
-
 - [Twitter](http://twitter.com/nedango)

--- a/profiles/pupils/profiles/danielsimaodasilva.md
+++ b/profiles/pupils/profiles/danielsimaodasilva.md
@@ -10,7 +10,6 @@ Quero me tornar um Front-End Engineer, capaz de compreender todo o fluxo do proj
 
 ## Alguns links para me conhecer melhor
 
-- [Facebook do Pupilo de Daniel Simão da Silva](https://www.facebook.com/simao.dev)
-- [Twitter do Pupilo de Daniel Simão da Silva](https://twitter.com/simaodeveloper)
-- [LinkedIn do Pupilo de Daniel Simão da Silva](https://www.linkedin.com/in/daniel-simao-da-silva)
-```
+- [Facebook](https://www.facebook.com/simao.dev)
+- [Twitter](https://twitter.com/simaodeveloper)
+- [LinkedIn](https://www.linkedin.com/in/daniel-simao-da-silva)

--- a/profiles/pupils/profiles/estevammr.md
+++ b/profiles/pupils/profiles/estevammr.md
@@ -12,4 +12,4 @@ Ser um desenvolvedor back end e ajudar as pessoas que estão iniciando e tem o m
 
 ## Alguns links para me conhecer melhor
 
-[LinkedIn](https://www.linkedin.com/in/estevamrodrigues/)
+- [LinkedIn](https://www.linkedin.com/in/estevamrodrigues/)

--- a/profiles/pupils/profiles/eubond.md
+++ b/profiles/pupils/profiles/eubond.md
@@ -12,6 +12,6 @@ Me aplicar na convergência do front end com o motion, mas, além disso resolver
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/flipmedeiros)
-[Twitter](https://twitter.com/flipmedeiros)
-[LinkedIn](https://www.linkedin.com/in/felipe-medeiros-a3574731/)
+- [Facebook](https://www.facebook.com/flipmedeiros)
+- [Twitter](https://twitter.com/flipmedeiros)
+- [LinkedIn](https://www.linkedin.com/in/felipe-medeiros-a3574731/)

--- a/profiles/pupils/profiles/fredrumond.md
+++ b/profiles/pupils/profiles/fredrumond.md
@@ -14,4 +14,4 @@ Me tornar um otimo profissional e um dia ajudar as pessoas que estao querendo en
 
 - [Facebook](https://www.facebook.com/frederico.drumond.33)
 - [Github](https://github.com/Fredrumond)
-- [LinkedIn](https://www.linkedin.com/in/frederico-xavier-drumond-85ab7483?trk=nav_responsive_tab_profile)
+- [LinkedIn](https://www.linkedin.com/in/frederico-xavier-drumond-85ab7483)

--- a/profiles/pupils/profiles/fredrumond.md
+++ b/profiles/pupils/profiles/fredrumond.md
@@ -12,6 +12,6 @@ Me tornar um otimo profissional e um dia ajudar as pessoas que estao querendo en
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/frederico.drumond.33)
-[Github](https://github.com/Fredrumond)
-[LinkedIn](https://www.linkedin.com/in/frederico-xavier-drumond-85ab7483?trk=nav_responsive_tab_profile)
+- [Facebook](https://www.facebook.com/frederico.drumond.33)
+- [Github](https://github.com/Fredrumond)
+- [LinkedIn](https://www.linkedin.com/in/frederico-xavier-drumond-85ab7483?trk=nav_responsive_tab_profile)

--- a/profiles/pupils/profiles/gabrielsouzaa.md
+++ b/profiles/pupils/profiles/gabrielsouzaa.md
@@ -7,6 +7,7 @@ Gabriel Souza
 Trabalhar em uma grande empresa multinacional.
 
 ## Alguns links para me conhecer melhor
-[Twitter](https://twitter.com/gabriels0uzaa)
-[GitHub](https://gitbub.com/gabrielsouzaa)
-[LinkedIn](https://br.linkedin.com/in/gabriel-souza-48735b82)
+
+- [Twitter](https://twitter.com/gabriels0uzaa)
+- [GitHub](https://gitbub.com/gabrielsouzaa)
+- [LinkedIn](https://br.linkedin.com/in/gabriel-souza-48735b82)

--- a/profiles/pupils/profiles/giovannicruz97.md
+++ b/profiles/pupils/profiles/giovannicruz97.md
@@ -8,7 +8,8 @@ Giovanni Cruz
 Participar de uma empresa que tenha impacto direto na sociedade
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/giovanni.cruz.1485)
-[Twitter](https://twitter.com/giovanni_cruz97)
-[GitHub](https://github.com/giovannicruz97)
-[LinkedIn](https://br.linkedin.com/in/giovanni-cruz-1011a6104)
+
+- [Facebook](https://www.facebook.com/giovanni.cruz.1485)
+- [Twitter](https://twitter.com/giovanni_cruz97)
+- [GitHub](https://github.com/giovannicruz97)
+- [LinkedIn](https://br.linkedin.com/in/giovanni-cruz-1011a6104)

--- a/profiles/pupils/profiles/hugo_almeida.md
+++ b/profiles/pupils/profiles/hugo_almeida.md
@@ -8,9 +8,10 @@ Hugo Almeida
 Tornar profissional JEDI FullStack, desenvolver e aperfeiçoar habilidades pessoais e profissionais, e assim com mais conhecimento apoiar projetos na web, ajudar outras pessoas a alcançarem seus sonhos, seja criando algo para eles ou ensinando tecnologia, programação...
 
 ## Alguns links para me conhecer melhor
-[Site pessoal](site-hugoalmeida.rhcliud.com)
-[Facebook](https://www.facebook.com/hugohbalmdeida)
-[Twitter](https://twitter.com/hugoalmeidab)
-[GitHub](https://github.com/hhalmeida)
-[LinkedIn](https://www.linkedin.com/in/hugohbalmeida)
+
+- [Site pessoal](site-hugoalmeida.rhcliud.com)
+- [Facebook](https://www.facebook.com/hugohbalmdeida)
+- [Twitter](https://twitter.com/hugoalmeidab)
+- [GitHub](https://github.com/hhalmeida)
+- [LinkedIn](https://www.linkedin.com/in/hugohbalmeida)
 

--- a/profiles/pupils/profiles/ingridmartins.md
+++ b/profiles/pupils/profiles/ingridmartins.md
@@ -12,5 +12,5 @@ Quero ser uma profissional de TI completa e competente
 
 ## Alguns links para me conhecer melhor
 
-* [LinkedIn](https://www.linkedin.com/in/ingrid-martins-356ab412b/)
-* [GitHub](https://github.com/imingrid)
+- [LinkedIn](https://www.linkedin.com/in/ingrid-martins-356ab412b/)
+- [GitHub](https://github.com/imingrid)

--- a/profiles/pupils/profiles/ismaelirc.md
+++ b/profiles/pupils/profiles/ismaelirc.md
@@ -12,5 +12,5 @@ Quero estudar e me aperfeiçoar em OO e tecnologias para backend
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](http://twitter.com/ismaelirc)
-[LinkedIn](http://linkedin.com/in/ismaelricardocosta/)
+- [Twitter](http://twitter.com/ismaelirc)
+- [LinkedIn](http://linkedin.com/in/ismaelricardocosta/)

--- a/profiles/pupils/profiles/italobessa.md
+++ b/profiles/pupils/profiles/italobessa.md
@@ -15,8 +15,6 @@ Conhecimento em HTML5, CSS3, JAVASCRIPT, BOOTSTRAP e DESIGN.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/brenda.rayane.564)
-
-[LinkedIn](https://br.linkedin.com/in/ítalo-bessa-1a291111a)
-
-[GitHub](https://github.com/ytalobessa)
+- [Facebook](https://www.facebook.com/brenda.rayane.564)
+- [LinkedIn](https://br.linkedin.com/in/ítalo-bessa-1a291111a)
+- [GitHub](https://github.com/ytalobessa)

--- a/profiles/pupils/profiles/jalawz.md
+++ b/profiles/pupils/profiles/jalawz.md
@@ -14,6 +14,6 @@ retribuir tudo aquilo que me foi passado.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Paulo Roberto Menezes](https://www.facebook.com/pauloroberto.menezes.5)
-[Twitter do Paulo Roberto Menezes](https://twitter.com/paulornmenezes)
-[LinkedIn do Paulo Roberto Menezes](https://www.linkedin.com/in/paulo-roberto-nunes-de-menezes-04940538?trk=nav_responsive_tab_profile)
+- [Facebook](https://www.facebook.com/pauloroberto.menezes.5)
+- [Twitter](https://twitter.com/paulornmenezes)
+- [LinkedIn](https://www.linkedin.com/in/paulo-roberto-nunes-de-menezes-04940538?trk=nav_responsive_tab_profile)

--- a/profiles/pupils/profiles/jalawz.md
+++ b/profiles/pupils/profiles/jalawz.md
@@ -8,12 +8,10 @@ Paulo Roberto Menezes
 
 ## Qual meu sonho na carreira?
 
-Quero me tornar um bom desenvolvedor e poder um dia ter autonomia para trabalhar
-em uma grande empresa ou em home office. Gostaria também de um dia poder
-retribuir tudo aquilo que me foi passado.
+Quero me tornar um bom desenvolvedor e poder um dia ter autonomia para trabalhar em uma grande empresa ou em home office. Gostaria também de um dia poder retribuir tudo aquilo que me foi passado.
 
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/pauloroberto.menezes.5)
 - [Twitter](https://twitter.com/paulornmenezes)
-- [LinkedIn](https://www.linkedin.com/in/paulo-roberto-nunes-de-menezes-04940538?trk=nav_responsive_tab_profile)
+- [LinkedIn](https://www.linkedin.com/in/paulo-roberto-nunes-de-menezes-04940538)

--- a/profiles/pupils/profiles/jeyzielgama.md
+++ b/profiles/pupils/profiles/jeyzielgama.md
@@ -12,6 +12,6 @@ Eu Sonho em se tornar um progamador back-end qualificado adepto de boas prática
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/JeyzielGama)
-[github](https://github.com/jeyziel)
-[telegram](https://telegram.me/jeyziel)
+- [Twitter](https://twitter.com/JeyzielGama)
+- [github](https://github.com/jeyziel)
+- [telegram](https://telegram.me/jeyziel)

--- a/profiles/pupils/profiles/johnyramos.md
+++ b/profiles/pupils/profiles/johnyramos.md
@@ -12,8 +12,8 @@ Quero ser front-end, poder contribuir com a comunidade e com novos desenvolvedor
 
 ## Alguns links para me conhecer melhor
 
-[FaceBook](https://www.facebook.com/johnyeramos)
+- [FaceBook](https://www.facebook.com/johnyeramos)
 
-[Twitter](https://twitter.com/JoeeyRamos)
+- [Twitter](https://twitter.com/JoeeyRamos)
 
-[LinkedIn](https://br.linkedin.com/in/johnyeramos)
+- [LinkedIn](https://br.linkedin.com/in/johnyeramos)

--- a/profiles/pupils/profiles/johnyramos.md
+++ b/profiles/pupils/profiles/johnyramos.md
@@ -13,7 +13,5 @@ Quero ser front-end, poder contribuir com a comunidade e com novos desenvolvedor
 ## Alguns links para me conhecer melhor
 
 - [FaceBook](https://www.facebook.com/johnyeramos)
-
 - [Twitter](https://twitter.com/JoeeyRamos)
-
 - [LinkedIn](https://br.linkedin.com/in/johnyeramos)

--- a/profiles/pupils/profiles/jonatan_vianna.md
+++ b/profiles/pupils/profiles/jonatan_vianna.md
@@ -8,12 +8,12 @@ Jonatan Vianna da Silva
 
 ## Qual meu sonho na carreira?
 
-Ter conhecimento e experiência para trabalhar como dev em projetos legais.<br />
-Ajudar pessoas a se desenvolverem.<br />
-Poder trabalhar remoto / freelance.<br />
+Ter conhecimento e experiência para trabalhar como dev em projetos legais.  
+Ajudar pessoas a se desenvolverem.  
+Poder trabalhar remoto / freelance.  
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://facebook.com/jonatan.vianna)
-[Twitter](https://twitter.com/jonatanvianna)
-[LinkedIn](https://linkedin.com/in/jonatanvianna/)
+- [Facebook](https://facebook.com/jonatan.vianna)
+- [Twitter](https://twitter.com/jonatanvianna)
+- [LinkedIn](https://linkedin.com/in/jonatanvianna/)

--- a/profiles/pupils/profiles/laryro.md
+++ b/profiles/pupils/profiles/laryro.md
@@ -15,12 +15,11 @@ Aprendi HTML, CSS e JS na raça, gostei da coisa, fiz um curso técnico, consegu
 ## Qual meu sonho na carreira?
 
 Manjar das arquiteturas de software tudo e repassar meu conhecimento (que hoje em dia é pouco, muito pouco, quase nada) pros próximos pupulinhos (tenho alma de professora <3).
+
 Queria ou trampar numa empresa que tenha uma causa legal pra apoiar e uma estrutura foda OU viver de freelas e poder me dedicar a causas socias (quem sabe um dia, né).
 
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://facebook.com/laryro)
-
 - [Twitter](https://twitter.com/laryro)
-
 - [LinkedIn](https://linkedin.com/in/laryro)

--- a/profiles/pupils/profiles/laryro.md
+++ b/profiles/pupils/profiles/laryro.md
@@ -19,8 +19,8 @@ Queria ou trampar numa empresa que tenha uma causa legal pra apoiar e uma estrut
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://facebook.com/laryro)
+- [Facebook](https://facebook.com/laryro)
 
-[Twitter](https://twitter.com/laryro)
+- [Twitter](https://twitter.com/laryro)
 
-[LinkedIn](https://linkedin.com/in/laryro)
+- [LinkedIn](https://linkedin.com/in/laryro)

--- a/profiles/pupils/profiles/leonardofaria.md
+++ b/profiles/pupils/profiles/leonardofaria.md
@@ -12,4 +12,4 @@ Atuar no mercado como Front-end e contruir minha carreira com base nisso.
 
 ## Alguns links para me conhecer melhor
 
-[GitHub](https://www.github.com/lecoleco45)
+- [GitHub](https://www.github.com/lecoleco45)

--- a/profiles/pupils/profiles/luan_vicente.md
+++ b/profiles/pupils/profiles/luan_vicente.md
@@ -10,6 +10,7 @@ Me tornar um profissional apto a desenvolver minhas funções da melhor forma po
 [Mais informações aqui](https://github.com/training-center/mentoria/issues/39)
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/idluaOn)
-[Twitter](https://www.twitter.com/idlua)
-[Site](http://idlua.me)
+
+- [Facebook](https://www.facebook.com/idluaOn)
+- [Twitter](https://www.twitter.com/idlua)
+- [Site](http://idlua.me)

--- a/profiles/pupils/profiles/lucas_gabriel.md
+++ b/profiles/pupils/profiles/lucas_gabriel.md
@@ -8,4 +8,5 @@ Lucas Gabriel Pereira Cavalheiro
 Um grande: Me tornar Java Web Full Stack
 
 ## Alguns links para me conhecer melhor
-[Facebook](https://www.facebook.com/luckagabriel)
+
+- [Facebook](https://www.facebook.com/luckagabriel)

--- a/profiles/pupils/profiles/lucascapistrano.md
+++ b/profiles/pupils/profiles/lucascapistrano.md
@@ -10,5 +10,5 @@ Meu sonho de carreira é ser referência na área de desenvolvimento.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook de Lucas Capistrano](https://www.facebook.com/lucas.capistrano.7)
-[LinkedIn de Lucas Capistrano](https://br.linkedin.com/in/lucascapistrano)  
+- [Facebook](https://www.facebook.com/lucas.capistrano.7)
+- [LinkedIn](https://br.linkedin.com/in/lucascapistrano)  

--- a/profiles/pupils/profiles/luizgabriell.md
+++ b/profiles/pupils/profiles/luizgabriell.md
@@ -8,10 +8,10 @@ Luiz Gabriel Silva de Araujo
 
 ## Qual meu sonho na carreira?
 
-Quero aprender desenvolvimento Front-End e Back-End e trilhar o caminho para me tornar um desenvolvedor FullStack.<br/>
+Quero aprender desenvolvimento Front-End e Back-End e trilhar o caminho para me tornar um desenvolvedor FullStack.  
 Meu sonho é aprender a criar sistemas úteis desdo zero para ajudar as pessoas e empresas.
 
-#Conhecimentos
+# Conhecimentos
 
 Sou literalmente um pupilo que conhece muito pouco (até mesmo quase nada) sobre o assunto e está em busca de lições e aprendizado.
 Atualmente só conheço linguagens de marcação (HTML e CSS), pouqussímo de C e um pouco de SQL Developer.
@@ -19,4 +19,4 @@ Espero deixar esta lista  de conhecimentos mais extensa muito em breve. :)
 
 ## Alguns links para me conhecer melhor
 
-Email: [lgabriell.araujo@gmail.com](mailto:lgabriell.araujo@gmail.com?subject="Contato GitHub")<br/>
+Email: [lgabriell.araujo@gmail.com](mailto:lgabriell.araujo@gmail.com?subject="Contato GitHub")

--- a/profiles/pupils/profiles/luizgabriell.md
+++ b/profiles/pupils/profiles/luizgabriell.md
@@ -19,4 +19,4 @@ Espero deixar esta lista  de conhecimentos mais extensa muito em breve. :)
 
 ## Alguns links para me conhecer melhor
 
-Email: [lgabriell.araujo@gmail.com](mailto:lgabriell.araujo@gmail.com?subject="Contato GitHub")
+- [lgabriell.araujo@gmail.com](lgabriell.araujo@gmail.com)

--- a/profiles/pupils/profiles/luizgabriell.md
+++ b/profiles/pupils/profiles/luizgabriell.md
@@ -19,4 +19,4 @@ Espero deixar esta lista  de conhecimentos mais extensa muito em breve. :)
 
 ## Alguns links para me conhecer melhor
 
-- [lgabriell.araujo@gmail.com](lgabriell.araujo@gmail.com)
+- [Email](mailto:lgabriell.araujo@gmail.com)

--- a/profiles/pupils/profiles/maiconkcond.md
+++ b/profiles/pupils/profiles/maiconkcond.md
@@ -15,5 +15,5 @@ Conseguir iniciar carreira na área, mas especificamente com desenvolvimento web
 
 - [Facebook](https://www.facebook.com/maiconhenriquekcond)
 - [Twitter](https://twitter.com/Maicon2013SP)
-- [LinkedIn](https://www.linkedin.com/in/maicon-henrique-raimundo-8441b368?trk=nav_responsive_tab_profile)
+- [LinkedIn](https://www.linkedin.com/in/maicon-henrique-raimundo-8441b368)
 - [Git](https://github.com/maiconkcond)

--- a/profiles/pupils/profiles/maiconkcond.md
+++ b/profiles/pupils/profiles/maiconkcond.md
@@ -13,7 +13,7 @@ Conseguir iniciar carreira na área, mas especificamente com desenvolvimento web
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/maiconhenriquekcond)
-[Twitter](https://twitter.com/Maicon2013SP)
-[LinkedIn](https://www.linkedin.com/in/maicon-henrique-raimundo-8441b368?trk=nav_responsive_tab_profile)
-[Git](https://github.com/maiconkcond)
+- [Facebook](https://www.facebook.com/maiconhenriquekcond)
+- [Twitter](https://twitter.com/Maicon2013SP)
+- [LinkedIn](https://www.linkedin.com/in/maicon-henrique-raimundo-8441b368?trk=nav_responsive_tab_profile)
+- [Git](https://github.com/maiconkcond)

--- a/profiles/pupils/profiles/marcelo_gomes.md
+++ b/profiles/pupils/profiles/marcelo_gomes.md
@@ -12,5 +12,5 @@ Meu sonho é ter forças para buscar conhecimento o resto da minha vida e conseq
 
 ## Alguns links para me conhecer melhor
 
-* [Facebook](https://www.facebook.com/marcelo.rgom)
-* [Twitter](https://twitter.com/marcrgo)
+- [Facebook](https://www.facebook.com/marcelo.rgom)
+- [Twitter](https://twitter.com/marcrgo)

--- a/profiles/pupils/profiles/marceloluizleite.md
+++ b/profiles/pupils/profiles/marceloluizleite.md
@@ -14,7 +14,7 @@ apto a implmenta-la.
 
 ## Alguns links para me conhecer melhor
 
-- [Email](marceloluiz.developer@gmail.com)
+- [Email](mailto:marceloluiz.developer@gmail.com)
 - [Facebook](https://www.facebook.com/marcelo.luiz.1426)
 - [Twitter](https://twitter.com/marceloluiz86)
 - [LinkedIn](https://br.linkedin.com/in/marceloluizleite)

--- a/profiles/pupils/profiles/marco_blos.md
+++ b/profiles/pupils/profiles/marco_blos.md
@@ -13,5 +13,4 @@ Meu sonho é igual discurso de Miss Universo... Ser autossuficiente a ponto de p
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://pt-br.facebook.com/people/Marco-Antonio/1394020870)
-
-- [LinkedIn](https://www.linkedin.com/in/marco-antonio-blos-de-souza-09471645?trk=nav_responsive_tab_profile_pic)
+- [LinkedIn](https://www.linkedin.com/in/marco-antonio-blos-de-souza-09471645)

--- a/profiles/pupils/profiles/marco_blos.md
+++ b/profiles/pupils/profiles/marco_blos.md
@@ -12,6 +12,6 @@ Meu sonho é igual discurso de Miss Universo... Ser autossuficiente a ponto de p
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Marco](https://pt-br.facebook.com/people/Marco-Antonio/1394020870)
+- [Facebook](https://pt-br.facebook.com/people/Marco-Antonio/1394020870)
 
-[LinkedIn do Marco](https://www.linkedin.com/in/marco-antonio-blos-de-souza-09471645?trk=nav_responsive_tab_profile_pic)
+- [LinkedIn](https://www.linkedin.com/in/marco-antonio-blos-de-souza-09471645?trk=nav_responsive_tab_profile_pic)

--- a/profiles/pupils/profiles/marcosabb.md
+++ b/profiles/pupils/profiles/marcosabb.md
@@ -12,4 +12,4 @@ Ser um Desenvolvedor Jedi nos paranauês do Frontend! :smile:
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/Marcos.abb10)
+- [Facebook](https://www.facebook.com/Marcos.abb10)

--- a/profiles/pupils/profiles/mateusrdgs.md
+++ b/profiles/pupils/profiles/mateusrdgs.md
@@ -12,5 +12,5 @@ Tenho como objetivo me especializar e me tornar referência na área de FrontEnd
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/mateusrdgs01)</br>
-[LinkedIn](https://br.linkedin.com/in/mateusrdgs)
+- [Facebook](https://www.facebook.com/mateusrdgs01)
+- [LinkedIn](https://br.linkedin.com/in/mateusrdgs)

--- a/profiles/pupils/profiles/matheus_mazeto.md
+++ b/profiles/pupils/profiles/matheus_mazeto.md
@@ -17,16 +17,9 @@ Skills: conhecimentos básicos em html, css e uma boa lógica de programação.
 ## Alguns links para me conhecer melhor
 
 - [mgmazeto@gmail.com](mgmazeto@gmail.com)
-
 - [Github](https://github.com/matheusmazeto)
-
 - [Facebook](https://www.facebook.com/matheusmazeto)
-
 - [Twitter](https://twitter.com/matheusmazeto)
-
 - [Instagram](https://www.instagram.com/mmazeto/)
-
 - [Linkedin](https://www.linkedin.com/in/matheus-mazeto-94076680/)
-
 - [Medium](https://medium.com/@matheusmazeto)
-

--- a/profiles/pupils/profiles/matheus_mazeto.md
+++ b/profiles/pupils/profiles/matheus_mazeto.md
@@ -16,17 +16,17 @@ Skills: conhecimentos básicos em html, css e uma boa lógica de programação.
 
 ## Alguns links para me conhecer melhor
 
-[mgmazeto@gmail.com](mgmazeto@gmail.com)
+- [mgmazeto@gmail.com](mgmazeto@gmail.com)
 
-[github](https://github.com/matheusmazeto)
+- [Github](https://github.com/matheusmazeto)
 
-[Facebook](https://www.facebook.com/matheusmazeto)
+- [Facebook](https://www.facebook.com/matheusmazeto)
 
-[Twitter](https://twitter.com/matheusmazeto)
+- [Twitter](https://twitter.com/matheusmazeto)
 
-[Instagram](https://www.instagram.com/mmazeto/)
+- [Instagram](https://www.instagram.com/mmazeto/)
 
-[Linkedin](https://www.linkedin.com/in/matheus-mazeto-94076680/)
+- [Linkedin](https://www.linkedin.com/in/matheus-mazeto-94076680/)
 
-[Medium](https://medium.com/@matheusmazeto)
+- [Medium](https://medium.com/@matheusmazeto)
 

--- a/profiles/pupils/profiles/matheus_mazeto.md
+++ b/profiles/pupils/profiles/matheus_mazeto.md
@@ -16,7 +16,7 @@ Skills: conhecimentos básicos em html, css e uma boa lógica de programação.
 
 ## Alguns links para me conhecer melhor
 
-- [mgmazeto@gmail.com](mgmazeto@gmail.com)
+- [Email](mailto:mgmazeto@gmail.com)
 - [Github](https://github.com/matheusmazeto)
 - [Facebook](https://www.facebook.com/matheusmazeto)
 - [Twitter](https://twitter.com/matheusmazeto)

--- a/profiles/pupils/profiles/mayarapimentel.md
+++ b/profiles/pupils/profiles/mayarapimentel.md
@@ -12,5 +12,5 @@ Quero me tornar uma desenvolvedora front-end, que tem entende bem de html, css, 
 
 ## Alguns links para me conhecer melhor
 
-[Linkedin](https://www.linkedin.com/in/mayara-pimentel-497a8630)
-[Facebook](https://www.facebook.com/mayaraluck)
+- [Linkedin](https://www.linkedin.com/in/mayara-pimentel-497a8630)
+- [Facebook](https://www.facebook.com/mayaraluck)

--- a/profiles/pupils/profiles/pamelasouza.md
+++ b/profiles/pupils/profiles/pamelasouza.md
@@ -12,6 +12,6 @@ Utilizar o conhecimento como designer gráfico e iniciar uma carreira como front
 
 ## Alguns links para me conhecer melhor
 
-[Portfolio](www.pamelasouza.com)
-[Perfil do Facebook](https://www.facebook.com/pamdora10)
-[Perfil do Pinterest](https://br.pinterest.com/pamqk10)
+- [Portfolio](www.pamelasouza.com)
+- [Perfil do Facebook](https://www.facebook.com/pamdora10)
+- [Perfil do Pinterest](https://br.pinterest.com/pamqk10)

--- a/profiles/pupils/profiles/paulohoffmann.md
+++ b/profiles/pupils/profiles/paulohoffmann.md
@@ -1,6 +1,6 @@
 # Mentor(a) responsável por mim
 
-[Danilo Agostinho] (https://github.com/training-center/mentoria/blob/master/profiles/mentors/profiles/danilo_agostinho.md)
+[Danilo Agostinho](https://github.com/training-center/mentoria/blob/master/profiles/mentors/profiles/danilo_agostinho.md)
 
 ## Meu Nome
 
@@ -12,6 +12,6 @@ Me tornar desenvolvedor full stack utilizando JavaScript.
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/phhoffmann)
-[Twitter](https://twitter.com/pauloohoffmann)
-[LinkedIn](https://www.linkedin.com/in/phhoffmann)
+- [Facebook](https://www.facebook.com/phhoffmann)
+- [Twitter](https://twitter.com/pauloohoffmann)
+- [LinkedIn](https://www.linkedin.com/in/phhoffmann)

--- a/profiles/pupils/profiles/paulopereiradosanjos.md
+++ b/profiles/pupils/profiles/paulopereiradosanjos.md
@@ -25,4 +25,4 @@ Ser um expert em Front e poder passar os conhecimentos aprendidos à novos desen
 - [Facebook](https://facebook.com/paulopereiradosanjos)
 - [Twitter](https://twitter.com/K3yboard)
 - [LinkedIn](https://www.linkedin.com/in/paulopereiradosanjos)
-- [Email](paulopereiradosanjos@gmail.com)
+- [Email](mailto:paulopereiradosanjos@gmail.com)

--- a/profiles/pupils/profiles/paulopereiradosanjos.md
+++ b/profiles/pupils/profiles/paulopereiradosanjos.md
@@ -21,10 +21,10 @@ Ser um expert em Front e poder passar os conhecimentos aprendidos à novos desen
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://facebook.com/paulopereiradosanjos)
+- [Facebook](https://facebook.com/paulopereiradosanjos)
 
-[Twitter](https://twitter.com/K3yboard)
+- [Twitter](https://twitter.com/K3yboard)
 
- [LinkedIn](https://www.linkedin.com/in/paulopereiradosanjos)
+- [LinkedIn](https://www.linkedin.com/in/paulopereiradosanjos)
 
 **Gmail**: paulopereiradosanjos@gmail.com

--- a/profiles/pupils/profiles/paulopereiradosanjos.md
+++ b/profiles/pupils/profiles/paulopereiradosanjos.md
@@ -10,7 +10,8 @@ Paulo Pereira dos Anjos
 
 Ser um expert em Front e poder passar os conhecimentos aprendidos à novos desenvolvedores.
 
-#Conhecimentos (básicos)
+## Conhecimentos
+
 - HTML5
 - CSS/Sass
 - Git
@@ -22,9 +23,6 @@ Ser um expert em Front e poder passar os conhecimentos aprendidos à novos desen
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://facebook.com/paulopereiradosanjos)
-
 - [Twitter](https://twitter.com/K3yboard)
-
 - [LinkedIn](https://www.linkedin.com/in/paulopereiradosanjos)
-
-**Gmail**: paulopereiradosanjos@gmail.com
+- [Email](paulopereiradosanjos@gmail.com)

--- a/profiles/pupils/profiles/pedbernardo.md
+++ b/profiles/pupils/profiles/pedbernardo.md
@@ -8,10 +8,7 @@ Pedro Bernardo
 
 ## Alguns links para me conhecer melhor
 
-> **FB**: [facebook.com/pedrovbernardo](http://facebook.com/pedrovbernardo)
-
-> **Twitter**: [twitter.com/pedbernardo](http://twitter.com/pedbernardo)
-
-> **Codepen**: [codepen.io/pedbernardo](http://codepen.io/pedbernardo)
-
-> **Email**: pedrovbernardo@gmail.com
+- [Codepen](http://codepen.io/pedbernardo)
+- [Twitter](http://twitter.com/pedbernardo)
+- [Facebook](http://facebook.com/pedrovbernardo)
+- [Email](mailto:pedrovbernardo@gmail.com)

--- a/profiles/pupils/profiles/polyana_andrade.md
+++ b/profiles/pupils/profiles/polyana_andrade.md
@@ -13,7 +13,5 @@ Atualmente trabalho com design gráfico, mas quero me especializar na área de U
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/poleandr)
-
 - [Behance](https://www.behance.net/polyandrade)
-
 - [LinkedIn](https://www.linkedin.com/in/polyandrade/)

--- a/profiles/pupils/profiles/polyana_andrade.md
+++ b/profiles/pupils/profiles/polyana_andrade.md
@@ -12,8 +12,8 @@ Atualmente trabalho com design gráfico, mas quero me especializar na área de U
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/poleandr)
+- [Facebook](https://www.facebook.com/poleandr)
 
-[Behance](https://www.behance.net/polyandrade)
+- [Behance](https://www.behance.net/polyandrade)
 
-[LinkedIn](https://www.linkedin.com/in/polyandrade/)
+- [LinkedIn](https://www.linkedin.com/in/polyandrade/)

--- a/profiles/pupils/profiles/rafadfaria.md
+++ b/profiles/pupils/profiles/rafadfaria.md
@@ -13,5 +13,5 @@ Trabalhar como desenvolver em outro país, tenho a vontade de vivênciar outra c
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/rafael.duarte.129)
-[Linkedin](https://www.linkedin.com/in/rafael-alves-duarte-619589a8?trk=hp-identity-name)
+- [Facebook](https://www.facebook.com/rafael.duarte.129)
+- [Linkedin](https://www.linkedin.com/in/rafael-alves-duarte-619589a8?trk=hp-identity-name)

--- a/profiles/pupils/profiles/rafaeldias.md
+++ b/profiles/pupils/profiles/rafaeldias.md
@@ -13,4 +13,4 @@ Trabalhar como desenvolver em outro país, tenho a vontade de vivênciar outra c
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/rafael.a.dias.71271)
+- [Facebook](https://www.facebook.com/rafael.a.dias.71271)

--- a/profiles/pupils/profiles/rafaelnsilva.md
+++ b/profiles/pupils/profiles/rafaelnsilva.md
@@ -6,7 +6,7 @@
 
 Rafael Nogueira Silva
 
-## Qual meu sonho na carreira?
+## Qual o meu sonho na carreira?
 
 Aperfeiçoar os estudos para melhorar todo meu trabalho como front-end e buscar novas oportunidades no futuro, tanto voltado para trabalho quanto para ajudar novos membros da comunidade
 

--- a/profiles/pupils/profiles/rafaelnsilva.md
+++ b/profiles/pupils/profiles/rafaelnsilva.md
@@ -12,5 +12,5 @@ Aperfeiçoar os estudos para melhorar todo meu trabalho como front-end e buscar 
 
 ## Alguns links para me conhecer melhor:
 
-[Twitter](http://www.twitter.com/rafaelnogueira)
-[Facebook](http://www.facebook.com/rafaelnogueira1)
+- [Twitter](http://www.twitter.com/rafaelnogueira)
+- [Facebook](http://www.facebook.com/rafaelnogueira1)

--- a/profiles/pupils/profiles/renesoares.md
+++ b/profiles/pupils/profiles/renesoares.md
@@ -14,4 +14,5 @@ disponibilizar para a comunidade. Também quero trabalhar em empresas fora do Br
 Atualmente eu trabalho com o PHP, HTML, CSS, JS, GIT e Postgresql
 
 ## Alguns links para me conhecer melhor
-[Facebook do Renê Soares](https://www.facebook.com/rene.soares.946)
+
+- [Facebook](https://www.facebook.com/rene.soares.946)

--- a/profiles/pupils/profiles/rpaggi.md
+++ b/profiles/pupils/profiles/rpaggi.md
@@ -12,5 +12,5 @@ Aprender bastante para poder migrar da minha atual área e descolar uns freelas 
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/rpaggi) | [Linkedin](https://www.linkedin.com/in/rpaggi)
-
+- [Twitter](https://twitter.com/rpaggi)
+- [Linkedin](https://www.linkedin.com/in/rpaggi)

--- a/profiles/pupils/profiles/simoneas02.md
+++ b/profiles/pupils/profiles/simoneas02.md
@@ -15,10 +15,10 @@ Conheço básico em HTML, CSS e JS, mas com uma vontade enorme de aprimorar meus
 
 ## Alguns links para me conhecer melhor
 
-[Facebook da Simone Amorim](https://www.facebook.com/simone.amorim.33)
+- [Facebook](https://www.facebook.com/simone.amorim.33)
 
-[Twitter da Simone Amorim](https://twitter.com/samorim02)
+- [Twitter](https://twitter.com/samorim02)
 
-[LinkedIn da Simone Amorim](https://www.linkedin.com/in/simone-amorim-311a3a87)
+- [LinkedIn](https://www.linkedin.com/in/simone-amorim-311a3a87)
 
-[GitHub da Simone Amorim](https://github.com/simoneas02)
+- [GitHub](https://github.com/simoneas02)

--- a/profiles/pupils/profiles/simoneas02.md
+++ b/profiles/pupils/profiles/simoneas02.md
@@ -10,15 +10,13 @@ Simone Amorim
 
 Busco aperfeiçoamento no desenvolvimento web para que esteja apta a trabalhar como freela e home office.
 
-#Conhecimentos
+## Conhecimentos
+
 Conheço básico em HTML, CSS e JS, mas com uma vontade enorme de aprimorar meus conhecimentos e poder retribuir com a comunidade.
 
 ## Alguns links para me conhecer melhor
 
 - [Facebook](https://www.facebook.com/simone.amorim.33)
-
 - [Twitter](https://twitter.com/samorim02)
-
 - [LinkedIn](https://www.linkedin.com/in/simone-amorim-311a3a87)
-
 - [GitHub](https://github.com/simoneas02)

--- a/profiles/pupils/profiles/thivieiratav.md
+++ b/profiles/pupils/profiles/thivieiratav.md
@@ -12,6 +12,6 @@ Sonho em montar meu proprio negócio e ou fazer parte de uma startup, home offic
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/ThivieiraTAV)
-[Twitter](https://twitter.com/thivieiratav)
-[LinkedIn](https://www.linkedin.com/in/thivieiratav)
+- [Facebook](https://www.facebook.com/ThivieiraTAV)
+- [Twitter](https://twitter.com/thivieiratav)
+- [LinkedIn](https://www.linkedin.com/in/thivieiratav)

--- a/profiles/pupils/profiles/twobanks.md
+++ b/profiles/pupils/profiles/twobanks.md
@@ -12,7 +12,7 @@ Quero participar ativamente de uma comunidade que compartilhe experiências e id
 
 ## Alguns links para me conhecer melhor
 
-* [Site Pessoal](http://twobanks.github.io/)
-* [Facebook](https://www.facebook.com/twobanks)
-* [Twitter](https://twitter.com/thbanks)
-* [LinkedIn](https://www.linkedin.com/in/thiago-gon%C3%A7alves-19867a84)
+- [Site Pessoal](http://twobanks.github.io/)
+- [Facebook](https://www.facebook.com/twobanks)
+- [Twitter](https://twitter.com/thbanks)
+- [LinkedIn](https://www.linkedin.com/in/thiago-gon%C3%A7alves-19867a84)

--- a/profiles/pupils/profiles/vicentimartins.md
+++ b/profiles/pupils/profiles/vicentimartins.md
@@ -14,6 +14,6 @@ seja repassando conhecimento.
 
 ## Alguns links para me conhecer melhor
 
-[Twitter](https://twitter.com/vicentimartins)
-[Github](https://github.com/vicentimartins)
-[Telegram](https://telegram.me/vicentimartins)
+- [Twitter](https://twitter.com/vicentimartins)
+- [Github](https://github.com/vicentimartins)
+- [Telegram](https://telegram.me/vicentimartins)

--- a/profiles/pupils/profiles/victorcopque.md
+++ b/profiles/pupils/profiles/victorcopque.md
@@ -12,6 +12,6 @@ Me tornar uma referência na minha área conseguindo interligar Business e Devel
 
 ## Alguns links para me conhecer melhor
 
-[Facebook](https://www.facebook.com/vcopque)
-[Twitter](https://twitter.com/copquevictor)
-[LinkedIn](https://www.linkedin.com/in/victorcopque/)
+- [Facebook](https://www.facebook.com/vcopque)
+- [Twitter](https://twitter.com/copquevictor)
+- [LinkedIn](https://www.linkedin.com/in/victorcopque/)


### PR DESCRIPTION
Hello @training-center/mentors,


## **Esse _PR_ só deve ser aceito com a revisão de mais de uma pessoa!**

Começou a força tarefa e resolvi fazer minha parte.

Alterei a maioria dos perfis dos `mentorados` para que o link das redes sociais/email se tornassem uma lista.

Notas importantes:

- Nem todos os perfis foram alterados (pois alguns estão usando `html` e não markdown)
- Esse pull-request pode futuramente quebrar muitos *pull-requests* de mentorados (mas isso é problema nosso, pois somos nós que administramos o que é aceito e se tiver erro, devemos corrigir)
- Removi coisas redundantes dos links como `meu perfil do facebook` passou a chamar apenas `Facebook`

Se houver alguma sugestão, estou aceitando, visto que estamos aqui para melhorar o repositório ;)