### PR TITLE
Adicionar o ano de 2017 na licença

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Centro de Treinamento
+Copyright (c) 2016 - 2017 Centro de Treinamento
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2017 Centro de Treinamento
+Copyright (c) 2016 - 2017 Training Center
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
O ano inicial permanece como sendo o mesmo (2016), mas como o projeto continua existindo, vamos _prolongando_ a licença...

Não sei até aonde isso é necessário, mas caso não seja útil podemos simplesmente ignorar...