### PR TITLE
Correção dos termos utilizados no perfis dos mentores

### DIFF
--- a/profiles/mentors/profiles/abner_alves.md
+++ b/profiles/mentors/profiles/abner_alves.md
@@ -19,7 +19,7 @@ Mentor para Desenvolvedores Front End UX/UI, CSS e semântica
 
 Manda aquele abraço nas redes sociais, da o joinha se inscreve aquele like ou pode mandar um e-mail para me@abnersajr.net
 
-## Mentorados
+## Mentorados(as)
 
 * [Mateus Rodrigues](/profiles/pupils/profiles/mateusrdgs.md)
 * Sofia Bareta - Aguardando Profile

--- a/profiles/mentors/profiles/abner_alves.md
+++ b/profiles/mentors/profiles/abner_alves.md
@@ -10,16 +10,16 @@ Mentor para Desenvolvedores Front End UX/UI, CSS e semântica
 
 ## Links
 
-* [Site do Mentor Abner Soares Alves Junior](https://abnersajr.net)
-* [Facebook do Mentor Abner Soares Alves Junior](https://fb.com/abnersajr)
-* [Twitter do Mentor Abner Soares Alves Junior](https://twitter.com/abnersajr)
-* [LinkedIn do Mentor Abner Soares Alves Junior](https://linkedin.com/in/abnersajr)
+* [Site](https://abnersajr.net)
+* [Facebook](https://fb.com/abnersajr)
+* [Twitter](https://twitter.com/abnersajr)
+* [LinkedIn](https://linkedin.com/in/abnersajr)
 
 ## Gostaria de retribuir a ajuda do Mentor Abner Soares Alves Junior?
 
 Manda aquele abraço nas redes sociais, da o joinha se inscreve aquele like ou pode mandar um e-mail para me@abnersajr.net
 
-## Pupilos do Mentor Abner Soares Alves Junior
+## Mentorados
 
 * [Mateus Rodrigues](/profiles/pupils/profiles/mateusrdgs.md)
 * Sofia Bareta - Aguardando Profile

--- a/profiles/mentors/profiles/ademilson_tonato.md
+++ b/profiles/mentors/profiles/ademilson_tonato.md
@@ -29,13 +29,13 @@ Eu gosto de construir aplicações web, dividir conhecimento, escrevendo artigos
 ## Gostaria de retribuir a ajuda do Ademílson Flores Tonato?
 
 Manda um "Olá" através das redes sociais ou pelo e-mail `ademilsonft@outlook.com` e depois retribua a mentoria ajudando outros iniciantes :)  
-Ei, estou aqui para auxiliar no seu desenvolvimento, se você quiser minha ajuda, não hesite em entrar em contato, ainda que meu perfil diga que não estou disponível para novos pupilos.
+Ei, estou aqui para auxiliar no seu desenvolvimento, se você quiser minha ajuda, não hesite em entrar em contato, ainda que meu perfil diga que não estou disponível para novos mentorados.
 
-## Pupilos
+## Mentorados
 
 - [Seu perfil pode estar aqui...](#)
 
-**Últimos pupilos**
+**Últimos mentorados**
 
 - [Amon Lucas (amonlucas)](/profiles/pupils/profiles/AmonLucas.md)
 - [Melissa Balsante (mibsbalsante)](/profiles/pupils/profiles/mibsbalsante.md)

--- a/profiles/mentors/profiles/ademilson_tonato.md
+++ b/profiles/mentors/profiles/ademilson_tonato.md
@@ -31,11 +31,11 @@ Eu gosto de construir aplicações web, dividir conhecimento, escrevendo artigos
 Manda um "Olá" através das redes sociais ou pelo e-mail `ademilsonft@outlook.com` e depois retribua a mentoria ajudando outros iniciantes :)  
 Ei, estou aqui para auxiliar no seu desenvolvimento, se você quiser minha ajuda, não hesite em entrar em contato, ainda que meu perfil diga que não estou disponível para novos mentorados.
 
-## Mentorados
+## Mentorados(as)
 
 - [Seu perfil pode estar aqui...](#)
 
-**Últimos mentorados**
+**Últimos mentorados(as)**
 
 - [Amon Lucas (amonlucas)](/profiles/pupils/profiles/AmonLucas.md)
 - [Melissa Balsante (mibsbalsante)](/profiles/pupils/profiles/mibsbalsante.md)

--- a/profiles/mentors/profiles/ademilson_tonato.md
+++ b/profiles/mentors/profiles/ademilson_tonato.md
@@ -34,10 +34,10 @@ Ei, estou aqui para auxiliar no seu desenvolvimento, se você quiser minha ajuda
 ## Mentorados(as)
 
 - [Seu perfil pode estar aqui...](#)
+- [Melissa Balsante (mibsbalsante)](/profiles/pupils/profiles/mibsbalsante.md)
 
 **Últimos mentorados(as)**
 
 - [Amon Lucas (amonlucas)](/profiles/pupils/profiles/AmonLucas.md)
-- [Melissa Balsante (mibsbalsante)](/profiles/pupils/profiles/mibsbalsante.md)
 - [Richard Manzoli (richardmanzoli)](/profiles/pupils/profiles/RichardManzoli.md)
 - [Werberth Vinícius (Werberth)](/profiles/pupils/profiles/WerberthVinicius.md)

--- a/profiles/mentors/profiles/alexandre_saudate.md
+++ b/profiles/mentors/profiles/alexandre_saudate.md
@@ -18,6 +18,6 @@ Arquiteto de Sistemas Java, com profundo conhecimento de integração, SOA, micr
 
 [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=alesaudate%40gmail%2ecom&lc=BR&item_name=Alexandre%20Saudate&currency_code=BRL&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted) ou mande um abraço para ele(a) no email alesaudate@gmail.com ou nas redes sociais.
 
-## Pupilos de [Alexandre Saudate]
+## Mentorados
 
 Em breve

--- a/profiles/mentors/profiles/alexandre_saudate.md
+++ b/profiles/mentors/profiles/alexandre_saudate.md
@@ -18,6 +18,6 @@ Arquiteto de Sistemas Java, com profundo conhecimento de integração, SOA, micr
 
 [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=alesaudate%40gmail%2ecom&lc=BR&item_name=Alexandre%20Saudate&currency_code=BRL&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted) ou mande um abraço para ele(a) no email alesaudate@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 Em breve

--- a/profiles/mentors/profiles/alexjunior012.md
+++ b/profiles/mentors/profiles/alexjunior012.md
@@ -6,10 +6,9 @@ Alex Junior
 
 ## Perfil
 
-Meu nome é Alex Junior, trabalho atualmente como Analista Programador PHP, mas atuo como desenvolvedor full stack.<br>
-Possuo 4 anos de experiencia com desenvolvimento, mesclando front-end com back-end.<br>
+Meu nome é Alex Junior, trabalho atualmente como Analista Programador PHP, mas atuo como desenvolvedor full stack.  
+Possuo 4 anos de experiencia com desenvolvimento, mesclando front-end com back-end.  
 Estou cursando 7º semestre de Ciência da Computação.
-
 
 ## Links
 
@@ -24,6 +23,6 @@ Estou cursando 7º semestre de Ciência da Computação.
 
 Só adicionar nas redes sociais, mandar um abraço e repassar o conhecimento adquirido.
 
-## Pupilos(as) do Alex Junior  
-[Romário Coimbra](/profiles/pupils/profiles/RomarioCoimbra.md)
+## Mentorados(as)
 
+[Romário Coimbra](/profiles/pupils/profiles/RomarioCoimbra.md)

--- a/profiles/mentors/profiles/aline_bastos.md
+++ b/profiles/mentors/profiles/aline_bastos.md
@@ -18,4 +18,4 @@ Mentora para iniciantes no desenvolvimento front-end.
 
 Retribua a mentoria ajudando outros iniciantes :)
 
-## Mentoradas(os) da Aline Bastos
+## Mentorados(as)

--- a/profiles/mentors/profiles/anderson_juhasc.md
+++ b/profiles/mentors/profiles/anderson_juhasc.md
@@ -25,7 +25,7 @@ Especialidades: HTML, CSS, JS, Node.js, Bitcoin e Blockchain
 
 Endereço bitcoin: 32hDGBp6CnVEuFBSQ9Xn9kfj3Z12XZFzFv ou mande um abraço para ele no email anderson.juhasc@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 * [Rafael Dias](/profiles/pupils/profiles/rafaeldias.md)
 * [André Ferreira](/profiles/pupils/profiles/AndreFerreira.md)

--- a/profiles/mentors/profiles/anderson_juhasc.md
+++ b/profiles/mentors/profiles/anderson_juhasc.md
@@ -25,7 +25,7 @@ Especialidades: HTML, CSS, JS, Node.js, Bitcoin e Blockchain
 
 Endereço bitcoin: 32hDGBp6CnVEuFBSQ9Xn9kfj3Z12XZFzFv ou mande um abraço para ele no email anderson.juhasc@gmail.com ou nas redes sociais.
 
-## Pupilos de Anderson Juhasc
+## Mentorados
 
 * [Rafael Dias](/profiles/pupils/profiles/rafaeldias.md)
 * [André Ferreira](/profiles/pupils/profiles/AndreFerreira.md)

--- a/profiles/mentors/profiles/andrea_zambrana.md
+++ b/profiles/mentors/profiles/andrea_zambrana.md
@@ -19,7 +19,7 @@ Mentora para desenvolvedores(as) Front End
 
 "Chega junto" nas redes sociais e manda um abraço.  
 
-## Mentorados(as) da Andréa Zambrana
+## Mentorados(as)
 
 [Ítalo Bessa](/profiles/pupils/profiles/italobessa.md)  
 [Josélia Costa](/profiles/pupils/profiles/JoseliaCosta.md)  

--- a/profiles/mentors/profiles/andrea_zambrana.md
+++ b/profiles/mentors/profiles/andrea_zambrana.md
@@ -19,7 +19,7 @@ Mentora para desenvolvedores(as) Front End
 
 "Chega junto" nas redes sociais e manda um abraço.  
 
-## Pupilos(as) da Andréa Zambrana  
+## Mentorados(as) da Andréa Zambrana
 
 [Ítalo Bessa](/profiles/pupils/profiles/italobessa.md)  
 [Josélia Costa](/profiles/pupils/profiles/JoseliaCosta.md)  

--- a/profiles/mentors/profiles/antonio_ladeia.md
+++ b/profiles/mentors/profiles/antonio_ladeia.md
@@ -21,4 +21,4 @@ Mentor para Desenvolvedores Backend
 
 Mande um abraço para ele nas redes sociais.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/antonio_ladeia.md
+++ b/profiles/mentors/profiles/antonio_ladeia.md
@@ -21,5 +21,4 @@ Mentor para Desenvolvedores Backend
 
 Mande um abraço para ele nas redes sociais.
 
-## Pupilos do Mentor da Antonio Ladeia
-
+## Mentorados

--- a/profiles/mentors/profiles/danilo_vaz.md
+++ b/profiles/mentors/profiles/danilo_vaz.md
@@ -31,7 +31,7 @@ Fora codar, também amo escrever. Tenho alguns textos no meu [Medium](https://me
 
 Mande um salve para danilovaz@hotmail.com.br ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 * [Hugo Almeida](/profiles/pupils/profiles/hugo_almeida.md)
 * [Safire Lauene](/profiles/pupils/profiles/SafireLauene.md)

--- a/profiles/mentors/profiles/danilo_vaz.md
+++ b/profiles/mentors/profiles/danilo_vaz.md
@@ -31,7 +31,7 @@ Fora codar, também amo escrever. Tenho alguns textos no meu [Medium](https://me
 
 Mande um salve para danilovaz@hotmail.com.br ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 * [Hugo Almeida](/profiles/pupils/profiles/hugo_almeida.md)
 * [Safire Lauene](/profiles/pupils/profiles/SafireLauene.md)

--- a/profiles/mentors/profiles/dener_rocha.md
+++ b/profiles/mentors/profiles/dener_rocha.md
@@ -24,7 +24,4 @@ Sócio na Unicorns Factory (https://www.unicornsfactory.com), uma equipe de espe
 
 Mande um abraço para ele no email.
 
-## Pupilos
-
-
-
+## Mentorados(as)

--- a/profiles/mentors/profiles/diego_ponciano.md
+++ b/profiles/mentors/profiles/diego_ponciano.md
@@ -20,7 +20,7 @@ Mentor para desenvolvedores Back-end
 Faça uma doação pra alguma causa animal ou de crianças carentes :D  
 Ou me manda um salve nas redes sociais.
 
-## Pupilos do Diego
+## Mentorados do Diego
 
 - [Beatriz Harumi Uezu](/profiles/pupils/profiles/BeatrizUezu.md)
 - [Josué Rodrigues](/profiles/pupils/profiles/josue23.md)

--- a/profiles/mentors/profiles/diego_ponciano.md
+++ b/profiles/mentors/profiles/diego_ponciano.md
@@ -20,7 +20,7 @@ Mentor para desenvolvedores Back-end
 Faça uma doação pra alguma causa animal ou de crianças carentes :D  
 Ou me manda um salve nas redes sociais.
 
-## Mentorados do Diego
+## Mentorados(as)
 
 - [Beatriz Harumi Uezu](/profiles/pupils/profiles/BeatrizUezu.md)
 - [Josué Rodrigues](/profiles/pupils/profiles/josue23.md)

--- a/profiles/mentors/profiles/diegomalone.md
+++ b/profiles/mentors/profiles/diegomalone.md
@@ -19,7 +19,7 @@ Sou formado em Ciência da Computação pela PUC Rio e já trabalho com desenvol
 * [Facebook](https://www.facebook.com/diegomalone)
 * Email: diegomalone@gmail.com
 
-## Pupilos
+## Mentorados
 
 - [Elton Coelho](../../pupils/profiles/elton_coelho.md)
 - [Daniel de Jesus Oliveira](../../pupils/profiles/DanielDeJesusOliveira.md)

--- a/profiles/mentors/profiles/diegomalone.md
+++ b/profiles/mentors/profiles/diegomalone.md
@@ -19,7 +19,7 @@ Sou formado em Ciência da Computação pela PUC Rio e já trabalho com desenvol
 * [Facebook](https://www.facebook.com/diegomalone)
 * Email: diegomalone@gmail.com
 
-## Mentorados
+## Mentorados(as)
 
 - [Elton Coelho](../../pupils/profiles/elton_coelho.md)
 - [Daniel de Jesus Oliveira](../../pupils/profiles/DanielDeJesusOliveira.md)

--- a/profiles/mentors/profiles/dorian_neto.md
+++ b/profiles/mentors/profiles/dorian_neto.md
@@ -36,12 +36,12 @@ Sou voluntário e membro ativo da comunidade [PHP com Rapadura](http://phpcomrap
 
 ou mande um abraço para ele no email doriansampaioneto@gmail.com ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 - [Iago Queiroz](/profiles/pupils/profiles/IagoQueiroz.md)
 - [Ismael Costa](/profiles/pupils/profiles/ismaelirc.md)
 
-### Últimos pupilos
+### Últimos mentorados
 - [Alex Santana Barazal](/profiles/pupils/profiles/AlexBarazal.md)
 - [William Meneses](/profiles/pupils/profiles/WilliamMeneses.md)
 - [Fernando Martins](/profiles/pupils/profiles/FernandoMartins.md)

--- a/profiles/mentors/profiles/dorian_neto.md
+++ b/profiles/mentors/profiles/dorian_neto.md
@@ -36,12 +36,12 @@ Sou voluntário e membro ativo da comunidade [PHP com Rapadura](http://phpcomrap
 
 ou mande um abraço para ele no email doriansampaioneto@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Iago Queiroz](/profiles/pupils/profiles/IagoQueiroz.md)
 - [Ismael Costa](/profiles/pupils/profiles/ismaelirc.md)
 
-### Últimos mentorados
+### Últimos mentorados(as)
 - [Alex Santana Barazal](/profiles/pupils/profiles/AlexBarazal.md)
 - [William Meneses](/profiles/pupils/profiles/WilliamMeneses.md)
 - [Fernando Martins](/profiles/pupils/profiles/FernandoMartins.md)

--- a/profiles/mentors/profiles/erik_figueiredo.md
+++ b/profiles/mentors/profiles/erik_figueiredo.md
@@ -31,7 +31,7 @@ Desenvolvimento Web em geral (Full Stack)
 
 Mande um abraço para ele no email contato@webdevbr.com.br ou nas redes sociais.
 
-## Pupilos do Erik
+## Mentorados
 
 * [Igor Oliveira](/profiles/pupils/profiles/IgoOliveira.md)
 * [Felipe Lacerda](/profiles/pupils/profiles/FelipeLacerda.md)

--- a/profiles/mentors/profiles/erik_figueiredo.md
+++ b/profiles/mentors/profiles/erik_figueiredo.md
@@ -31,7 +31,7 @@ Desenvolvimento Web em geral (Full Stack)
 
 Mande um abraço para ele no email contato@webdevbr.com.br ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 * [Igor Oliveira](/profiles/pupils/profiles/IgoOliveira.md)
 * [Felipe Lacerda](/profiles/pupils/profiles/FelipeLacerda.md)

--- a/profiles/mentors/profiles/erikpatekoski.md
+++ b/profiles/mentors/profiles/erikpatekoski.md
@@ -19,4 +19,5 @@ Mentor para QA's e Automatizadores
 
 Manda salve nas redes sociais :)
 
-## Pupilos do Mentor Érik Patekoski
+## Mentorados
+

--- a/profiles/mentors/profiles/erikpatekoski.md
+++ b/profiles/mentors/profiles/erikpatekoski.md
@@ -19,5 +19,4 @@ Mentor para QA's e Automatizadores
 
 Manda salve nas redes sociais :)
 
-## Mentorados
-
+## Mentorados(as)

--- a/profiles/mentors/profiles/evaldo-barbosa.md
+++ b/profiles/mentors/profiles/evaldo-barbosa.md
@@ -28,6 +28,6 @@ Posso ajudá-lo com: Desenvolvimento web, Melhorar como palestrante, Agile e Com
 
 Remende o trabalho dele no linkedin e outras redes sociais. Se for o caso, tem também o [PagSeguro](https://pag.ae/bjmht6d).
 
-## Pupilos de Evaldo Barbosa
+## Mentorados
 
-* Quer ser meu pupilo?
+* Quer ser meu mentorado?

--- a/profiles/mentors/profiles/evaldo-barbosa.md
+++ b/profiles/mentors/profiles/evaldo-barbosa.md
@@ -28,6 +28,6 @@ Posso ajudá-lo com: Desenvolvimento web, Melhorar como palestrante, Agile e Com
 
 Remende o trabalho dele no linkedin e outras redes sociais. Se for o caso, tem também o [PagSeguro](https://pag.ae/bjmht6d).
 
-## Mentorados
+## Mentorados(as)
 
 * Quer ser meu mentorado?

--- a/profiles/mentors/profiles/felipe_fernandes.md
+++ b/profiles/mentors/profiles/felipe_fernandes.md
@@ -20,4 +20,4 @@ Sou formato em análise de sistemas com pós-graduação em animação, e possuo
 
 Mande um abraço para ele no email felipefernandesweb@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/felipe_fernandes.md
+++ b/profiles/mentors/profiles/felipe_fernandes.md
@@ -20,6 +20,4 @@ Sou formato em análise de sistemas com pós-graduação em animação, e possuo
 
 Mande um abraço para ele no email felipefernandesweb@gmail.com ou nas redes sociais.
 
-## Pupilos do Felipe Fernandes
-
-* 
+## Mentorados

--- a/profiles/mentors/profiles/felipe_fialho.md
+++ b/profiles/mentors/profiles/felipe_fialho.md
@@ -33,7 +33,7 @@ Quem me conhece sabe que apesar de estar estudando JavaScript a todo vapor, sou 
 
 Mande um salve para hi@felipefialho.com ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 - [André Mendes](https://github.com/andre-mendes)
 - [Felipe Medeiros](https://github.com/eubond)

--- a/profiles/mentors/profiles/felipe_fialho.md
+++ b/profiles/mentors/profiles/felipe_fialho.md
@@ -33,7 +33,7 @@ Quem me conhece sabe que apesar de estar estudando JavaScript a todo vapor, sou 
 
 Mande um salve para hi@felipefialho.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [André Mendes](https://github.com/andre-mendes)
 - [Felipe Medeiros](https://github.com/eubond)

--- a/profiles/mentors/profiles/felipe_orlando.md
+++ b/profiles/mentors/profiles/felipe_orlando.md
@@ -22,6 +22,6 @@ Trabalho atualmente com Javascript, Ruby on Rails, HTML, CSS, SASS, SCSS, jQuery
 
 Segue no Github, Twitter e chama pra uns café. ☕️
 
-## Pupilos de Felipe
+## Mentorados(as)
 
 **vemnimim**

--- a/profiles/mentors/profiles/felipe_rank.md
+++ b/profiles/mentors/profiles/felipe_rank.md
@@ -13,8 +13,9 @@ Mentoria para Back-End (PHP, fw Laravel) e Front-End (HTML/CSS/Javascript)
 * [Facebook](https://www.facebook.com/raank92)
 * [LinkedIn](https://www.linkedin.com/in/raank/)
 
-## Pupilos
-<a href="https://github.com/RafaelaCassianoCampos">Rafaela Cassiano Campos</a>
+## Mentorados
+
+- [Rafaela Cassiano Campos](https://github.com/RafaelaCassianoCampos)
 
 ## Gostaria de retribuir a ajuda do(a) Felipe Rank?
 

--- a/profiles/mentors/profiles/felipe_rank.md
+++ b/profiles/mentors/profiles/felipe_rank.md
@@ -13,7 +13,7 @@ Mentoria para Back-End (PHP, fw Laravel) e Front-End (HTML/CSS/Javascript)
 * [Facebook](https://www.facebook.com/raank92)
 * [LinkedIn](https://www.linkedin.com/in/raank/)
 
-## Mentorados
+## Mentorados(as)
 
 - [Rafaela Cassiano Campos](https://github.com/RafaelaCassianoCampos)
 

--- a/profiles/mentors/profiles/fernandabernardo.md
+++ b/profiles/mentors/profiles/fernandabernardo.md
@@ -21,5 +21,4 @@ Tenho 22 anos e trabalho como front-end no Elo7. Me formei em Sistemas de Inform
 
 Mande um abraço para ela no email fernandabernardo94@gmail.com ou nas redes sociais.
 
-## Mentorados
-* 
+## Mentorados(as)

--- a/profiles/mentors/profiles/fernandabernardo.md
+++ b/profiles/mentors/profiles/fernandabernardo.md
@@ -21,5 +21,5 @@ Tenho 22 anos e trabalho como front-end no Elo7. Me formei em Sistemas de Inform
 
 Mande um abraço para ela no email fernandabernardo94@gmail.com ou nas redes sociais.
 
-## Pupilos de Fernanda Bernardo
+## Mentorados
 * 

--- a/profiles/mentors/profiles/fernando_fleury.md
+++ b/profiles/mentors/profiles/fernando_fleury.md
@@ -19,6 +19,6 @@ Trabalho como desenvolvedor front-end há uns 6 anos e adoro de verdade o que fa
 
 Nada, só ajudar os outros quando puder.
 
-## Pupilos(as) de Fernando Moreira
+## Mentorados(as)
 
 [Erik Matos](/profiles/pupils/profiles/ErikG_matos.md) 

--- a/profiles/mentors/profiles/fernando_moreira.md
+++ b/profiles/mentors/profiles/fernando_moreira.md
@@ -22,7 +22,7 @@ Hoje sou especializado em desenvolvimento web usando Wordpress com foco em front
 
 Mande um abraço para ele no email nandomoreira.me@gmail.com ou nas redes sociais.
 
-## Pupilos(as) de Fernando Moreira
+## Mentorados(as)
 
 [Eduardo S. de Araujo](/profiles/pupils/profiles/edusar.md)
 [Ingrid Rauany Dias Soares](/profiles/pupils/profiles/IngridRauany.md)

--- a/profiles/mentors/profiles/gian_souza.md
+++ b/profiles/mentors/profiles/gian_souza.md
@@ -19,4 +19,4 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço, obrigado, thank you ou gracias para ele no email giansouzafreitas@gmail.com ou nas redes sociais.
 
-## Pupilos
+## Mentorados

--- a/profiles/mentors/profiles/gian_souza.md
+++ b/profiles/mentors/profiles/gian_souza.md
@@ -19,4 +19,4 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço, obrigado, thank you ou gracias para ele no email giansouzafreitas@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/giovannicruz97.md
+++ b/profiles/mentors/profiles/giovannicruz97.md
@@ -17,7 +17,7 @@ Me chamo Giovanni Cruz, sou desenvolvedor Backend com foco em PHP. Amante de Lar
 
 Entre em contato pelo meu email: giovanni.cruz97@hotmail.com
 
-## Pupilos
+## Mentorados
 
 * [Victor Maciel](/profiles/pupils/profiles/VictorMaciel.md)
 * [Luiz Glatz](/profiles/pupils/profiles/LuizGlatz.md)

--- a/profiles/mentors/profiles/giovannicruz97.md
+++ b/profiles/mentors/profiles/giovannicruz97.md
@@ -17,7 +17,7 @@ Me chamo Giovanni Cruz, sou desenvolvedor Backend com foco em PHP. Amante de Lar
 
 Entre em contato pelo meu email: giovanni.cruz97@hotmail.com
 
-## Mentorados
+## Mentorados(as)
 
 * [Victor Maciel](/profiles/pupils/profiles/VictorMaciel.md)
 * [Luiz Glatz](/profiles/pupils/profiles/LuizGlatz.md)

--- a/profiles/mentors/profiles/guilherme-augusto-henschel.md
+++ b/profiles/mentors/profiles/guilherme-augusto-henschel.md
@@ -20,6 +20,6 @@ Também posso dar algumas dicas sobre Fotografia e Música :)
 
 Deixe uma recomendação (escrita ou votando nas minhas skills) no meu LinkedIn
 
-## Pupilos de Guilherme Augusto
+## Mentorados
 
 - [Thiago Phillip](/profiles/pupils/profiles/ThiagoPhillip.md)

--- a/profiles/mentors/profiles/guilherme-augusto-henschel.md
+++ b/profiles/mentors/profiles/guilherme-augusto-henschel.md
@@ -20,6 +20,6 @@ Também posso dar algumas dicas sobre Fotografia e Música :)
 
 Deixe uma recomendação (escrita ou votando nas minhas skills) no meu LinkedIn
 
-## Mentorados
+## Mentorados(as)
 
 - [Thiago Phillip](/profiles/pupils/profiles/ThiagoPhillip.md)

--- a/profiles/mentors/profiles/guilhermepontes.md
+++ b/profiles/mentors/profiles/guilhermepontes.md
@@ -31,7 +31,7 @@ Já trabalhei com todo tipo de tecnologia possível, mas tenho como experiência
 
 Só mandar um salve para [@guiiipontes](http://twitter.com/guiiipontes) no Twitter!
 
-## Mentorados
+## Mentorados(as)
 
 * [Maicon Gomes](/profiles/pupils/profiles/atreyucore.md)
 * [Marcos Borges](/profiles/pupils/profiles/marcosabb.md)

--- a/profiles/mentors/profiles/guilhermepontes.md
+++ b/profiles/mentors/profiles/guilhermepontes.md
@@ -31,7 +31,7 @@ Já trabalhei com todo tipo de tecnologia possível, mas tenho como experiência
 
 Só mandar um salve para [@guiiipontes](http://twitter.com/guiiipontes) no Twitter!
 
-## Pupilos
+## Mentorados
 
 * [Maicon Gomes](/profiles/pupils/profiles/atreyucore.md)
 * [Marcos Borges](/profiles/pupils/profiles/marcosabb.md)

--- a/profiles/mentors/profiles/henrique_maich.md
+++ b/profiles/mentors/profiles/henrique_maich.md
@@ -46,5 +46,5 @@ Conheco um pouco sobre DevOps, automatizando processos de Build/Deploy em Cloud,
 
 Busque o conhecimento, busque o que te faz feliz e depois tente mostrar para aqueles que te seguem o caminhos que sequistes.
 
-## Pupilos de Henrique
+## Mentorados
 

--- a/profiles/mentors/profiles/henrique_maich.md
+++ b/profiles/mentors/profiles/henrique_maich.md
@@ -46,5 +46,4 @@ Conheco um pouco sobre DevOps, automatizando processos de Build/Deploy em Cloud,
 
 Busque o conhecimento, busque o que te faz feliz e depois tente mostrar para aqueles que te seguem o caminhos que sequistes.
 
-## Mentorados
-
+## Mentorados(as)

--- a/profiles/mentors/profiles/jessuir_cleydson.md
+++ b/profiles/mentors/profiles/jessuir_cleydson.md
@@ -17,7 +17,7 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço para ele no email jessuircleydson@gmail.com ou deixe um depoimento no [LinkedIn](https://br.linkedin.com/in/jessuir-cleydson-8223b640) :)
 
-## Mentorados
+## Mentorados(as)
 
 * [Bruno Xavier de Melo](/profiles/pupils/profiles/BrunoMelo.md)
 * [Marcelo Henrique de Souza e Silva](/profiles/pupils/profiles/MarceloHenrique.md)

--- a/profiles/mentors/profiles/jessuir_cleydson.md
+++ b/profiles/mentors/profiles/jessuir_cleydson.md
@@ -17,8 +17,7 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço para ele no email jessuircleydson@gmail.com ou deixe um depoimento no [LinkedIn](https://br.linkedin.com/in/jessuir-cleydson-8223b640) :)
 
-## Pupilos
-
+## Mentorados
 
 * [Bruno Xavier de Melo](/profiles/pupils/profiles/BrunoMelo.md)
 * [Marcelo Henrique de Souza e Silva](/profiles/pupils/profiles/MarceloHenrique.md)

--- a/profiles/mentors/profiles/jhonatan.md
+++ b/profiles/mentors/profiles/jhonatan.md
@@ -20,4 +20,4 @@ Atualmente trabalho em uma Escola como Desenvolvedor Web.
 
 Repasse todo o conhecimento adquirido, da forma que conseguir. Isso não custa dinheiro e pode mudar o mundo!
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/jhonatan.md
+++ b/profiles/mentors/profiles/jhonatan.md
@@ -20,4 +20,4 @@ Atualmente trabalho em uma Escola como Desenvolvedor Web.
 
 Repasse todo o conhecimento adquirido, da forma que conseguir. Isso não custa dinheiro e pode mudar o mundo!
 
-## Pupilos de Jhonatan
+## Mentorados

--- a/profiles/mentors/profiles/kiver.md
+++ b/profiles/mentors/profiles/kiver.md
@@ -18,10 +18,8 @@ Sou formado em Analise e Desenvolvimento de Software desde 2010 e possuo especia
 
 Mande um abraço para ele no email.
 
-## Pupilos do Kiver Teixeira
+## Mentorados
 
 * [Gabriel Berto](/profiles/pupils/profiles/GabrielBerto.md)
 * [Leticia Costa](/profiles/pupils/profiles/LeticiaCosta.md)
 * [Eduardo S. Araujo](/profiles/pupils/profiles/EduardoSdeAraujo.md)
-
-

--- a/profiles/mentors/profiles/kiver.md
+++ b/profiles/mentors/profiles/kiver.md
@@ -18,7 +18,7 @@ Sou formado em Analise e Desenvolvimento de Software desde 2010 e possuo especia
 
 Mande um abraço para ele no email.
 
-## Mentorados
+## Mentorados(as)
 
 * [Gabriel Berto](/profiles/pupils/profiles/GabrielBerto.md)
 * [Leticia Costa](/profiles/pupils/profiles/LeticiaCosta.md)

--- a/profiles/mentors/profiles/leonardo_saraiva.md
+++ b/profiles/mentors/profiles/leonardo_saraiva.md
@@ -27,7 +27,7 @@ Gostaria de retribuir um pouco à comunidade com o conhecimento que consegui adq
 
 Só dar um chego nas redes sociais e mandar um `_o/`
 
-## Mentorados
+## Mentorados(as)
 
 - [Henri Oiwa](/profiles/pupils/profiles/HenriOiwa.md)
 - [Marcelo Luiz Leite](/profiles/pupils/profiles/marceloluizleite.md)

--- a/profiles/mentors/profiles/leonardo_saraiva.md
+++ b/profiles/mentors/profiles/leonardo_saraiva.md
@@ -27,7 +27,8 @@ Gostaria de retribuir um pouco à comunidade com o conhecimento que consegui adq
 
 Só dar um chego nas redes sociais e mandar um `_o/`
 
-## Pupilos
+## Mentorados
+
 - [Henri Oiwa](/profiles/pupils/profiles/HenriOiwa.md)
 - [Marcelo Luiz Leite](/profiles/pupils/profiles/marceloluizleite.md)
 - [Phillip Freitas](/profiles/pupils/profiles/PhillipFreitas.md)

--- a/profiles/mentors/profiles/lucas_henrique.md
+++ b/profiles/mentors/profiles/lucas_henrique.md
@@ -40,9 +40,8 @@ Tenha a base, que você domina o mundo ! ;)
 
 Dá um feedback lá no https://br.linkedin.com/in/lucashenriqueps93 e é nois !
 
-## Pupilos
+## Mentorados
 
 * [Gustavo César Domingos Siqueira](/profiles/pupils/profiles/G18Siqueira.md)
 * [Alex Avila](/profiles/pupils/profiles/AlexAvila.md) 
 * [LeonanMachado](/profiles/pupils/profiles/LeonanMachado.md)
-

--- a/profiles/mentors/profiles/lucas_henrique.md
+++ b/profiles/mentors/profiles/lucas_henrique.md
@@ -40,7 +40,7 @@ Tenha a base, que você domina o mundo ! ;)
 
 Dá um feedback lá no https://br.linkedin.com/in/lucashenriqueps93 e é nois !
 
-## Mentorados
+## Mentorados(as)
 
 * [Gustavo César Domingos Siqueira](/profiles/pupils/profiles/G18Siqueira.md)
 * [Alex Avila](/profiles/pupils/profiles/AlexAvila.md) 

--- a/profiles/mentors/profiles/lucas_santos.md
+++ b/profiles/mentors/profiles/lucas_santos.md
@@ -28,7 +28,7 @@ Mentor de desenvolvimento fullstack: Front-End, Back-End, Infraestrutura e DevOp
 
 Doe um valor no [pagseguro](https://pag.ae/bblYF88), [paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=25FDHU9XUD7UL) ou também mande um abraço para ele(a) no email [lhs.santoss@gmail.com](mailto:lhs.santoss@gmail.com) ou nas redes sociais.
 
-## Pupilos de Lucas
+## Mentorados
 
 - [Victor Copque](/profiles/pupils/profiles/victorcopque.md)
 - [Allyson Thales](/profiles/pupils/profiles/allysonthales.md)

--- a/profiles/mentors/profiles/lucas_santos.md
+++ b/profiles/mentors/profiles/lucas_santos.md
@@ -28,7 +28,7 @@ Mentor de desenvolvimento fullstack: Front-End, Back-End, Infraestrutura e DevOp
 
 Doe um valor no [pagseguro](https://pag.ae/bblYF88), [paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=25FDHU9XUD7UL) ou também mande um abraço para ele(a) no email [lhs.santoss@gmail.com](mailto:lhs.santoss@gmail.com) ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Victor Copque](/profiles/pupils/profiles/victorcopque.md)
 - [Allyson Thales](/profiles/pupils/profiles/allysonthales.md)

--- a/profiles/mentors/profiles/lucaspinto.md
+++ b/profiles/mentors/profiles/lucaspinto.md
@@ -21,7 +21,7 @@ Tecnologias que possuo know-how para mentor: Javascript (AngularJS, EmberJS, Nod
 
 Mande um alô! para lucas.henrique223@gmail.com ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 - Heitor Augusto Borges Pereira
 - Antonio Marcos

--- a/profiles/mentors/profiles/lucaspinto.md
+++ b/profiles/mentors/profiles/lucaspinto.md
@@ -21,7 +21,7 @@ Tecnologias que possuo know-how para mentor: Javascript (AngularJS, EmberJS, Nod
 
 Mande um alô! para lucas.henrique223@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - Heitor Augusto Borges Pereira
 - Antonio Marcos

--- a/profiles/mentors/profiles/luiz_felipe_limeira.md
+++ b/profiles/mentors/profiles/luiz_felipe_limeira.md
@@ -32,7 +32,7 @@ Possuo conhecimento nas seguintes tecnologias:
 
 Mande um "Hello World" no email lflimeira02@gmail.com ou nas redes sociais e ajude outras pessoas.
 
-## Pupilos
+## Mentorados
 
 * [Thiago Morastico Cruz](../../pupils/profiles/ThiagoMorasticoCruz.md)
 * [Enrico Augusto Viceconti](../../pupils/profiles/Eviceconti.md)
@@ -42,4 +42,3 @@ Mande um "Hello World" no email lflimeira02@gmail.com ou nas redes sociais e aju
 * [André Almeida](../../pupils/profiles/AndreAlmeida.md)
 * [Kaique Xavier Atalla](../../pupils/profiles/Kaique_Xavier_Atalla.md)
 * [Lucas Lopes de Moura](../../pupils/profiles/LucasMoura.md)
-

--- a/profiles/mentors/profiles/luiz_felipe_limeira.md
+++ b/profiles/mentors/profiles/luiz_felipe_limeira.md
@@ -32,7 +32,7 @@ Possuo conhecimento nas seguintes tecnologias:
 
 Mande um "Hello World" no email lflimeira02@gmail.com ou nas redes sociais e ajude outras pessoas.
 
-## Mentorados
+## Mentorados(as)
 
 * [Thiago Morastico Cruz](../../pupils/profiles/ThiagoMorasticoCruz.md)
 * [Enrico Augusto Viceconti](../../pupils/profiles/Eviceconti.md)

--- a/profiles/mentors/profiles/luiz_fernando.md
+++ b/profiles/mentors/profiles/luiz_fernando.md
@@ -18,6 +18,6 @@ Eterno estudante, desenvolvedor web e mobile [iOs/android (react-native)]
 
 Conta paypal: fernandoaff1@gmail.com ou mande um abraço para ele(a) no email fernandoaff1@gmail.com ou nas redes sociais.
 
-## Pupilos de Luiz Fernando
+## Mentorados
 
 - [Adeonir Kohl](/profiles/pupils/profiles/AdeonirKohl.md)

--- a/profiles/mentors/profiles/luiz_fernando.md
+++ b/profiles/mentors/profiles/luiz_fernando.md
@@ -18,6 +18,6 @@ Eterno estudante, desenvolvedor web e mobile [iOs/android (react-native)]
 
 Conta paypal: fernandoaff1@gmail.com ou mande um abraço para ele(a) no email fernandoaff1@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Adeonir Kohl](/profiles/pupils/profiles/AdeonirKohl.md)

--- a/profiles/mentors/profiles/luiz_paulof.md
+++ b/profiles/mentors/profiles/luiz_paulof.md
@@ -17,6 +17,6 @@ Mentor para desenvolvedores Wordpress e Woocommerce
 
 [faça uma doação usando o PagSeguro](https://pag.ae/bl04Sp) ou mande um abraço para ele no email luizpbills@gmail.com ou nas redes sociais.
 
-## Pupilos do Luiz Paulo Ferreira
+## Mentorados
 
 - [Anderson Nascimento](/profiles/pupils/profiles/AndersonNascimento.md)

--- a/profiles/mentors/profiles/luiz_paulof.md
+++ b/profiles/mentors/profiles/luiz_paulof.md
@@ -17,6 +17,6 @@ Mentor para desenvolvedores Wordpress e Woocommerce
 
 [faça uma doação usando o PagSeguro](https://pag.ae/bl04Sp) ou mande um abraço para ele no email luizpbills@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Anderson Nascimento](/profiles/pupils/profiles/AndersonNascimento.md)

--- a/profiles/mentors/profiles/luiz_tanure.md
+++ b/profiles/mentors/profiles/luiz_tanure.md
@@ -34,8 +34,7 @@ Posso ajudar em diversos níveis e assunstos, principalmente:
 * [Twitter](https://twitter.com/tanure)
 * [LinkedIn](https://www.linkedin.com/in/letanure/)
 
-
-## Mentorados
+## Mentorados(as)
 
 - Lucas Barbosa
 - Magno Lemos

--- a/profiles/mentors/profiles/luiz_tanure.md
+++ b/profiles/mentors/profiles/luiz_tanure.md
@@ -35,7 +35,7 @@ Posso ajudar em diversos níveis e assunstos, principalmente:
 * [LinkedIn](https://www.linkedin.com/in/letanure/)
 
 
-## Pupilos de Luiz Tanure
+## Mentorados
 
 - Lucas Barbosa
 - Magno Lemos

--- a/profiles/mentors/profiles/marcus_beckenkamp.md
+++ b/profiles/mentors/profiles/marcus_beckenkamp.md
@@ -23,4 +23,4 @@ Hoje trabalha em uma startup como desenvolvedor sênior.
 
 Mande um abraço para ele no email contato@mbeck.com.br ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/marcus_beckenkamp.md
+++ b/profiles/mentors/profiles/marcus_beckenkamp.md
@@ -23,5 +23,4 @@ Hoje trabalha em uma startup como desenvolvedor sênior.
 
 Mande um abraço para ele no email contato@mbeck.com.br ou nas redes sociais.
 
-## Pupilos de Marcus
-
+## Mentorados

--- a/profiles/mentors/profiles/matheus_fidelis.md
+++ b/profiles/mentors/profiles/matheus_fidelis.md
@@ -27,6 +27,6 @@ Nas horas vagas eu sou um namorado coruja de uma moça linda, colecionador de qu
 
 Mande um abraço para ele(a) no email msfidelis01@gmail.com ou no Twitter.
 
-## Pupilos de Matheus
+## Mentorados
 
 - [Igor Oliveira](/profiles/pupils/profiles/IgoOliveira.md) - [Projeto prático da mentoria](https://github.com/devigor/mentoria-devops)

--- a/profiles/mentors/profiles/matheus_fidelis.md
+++ b/profiles/mentors/profiles/matheus_fidelis.md
@@ -27,6 +27,6 @@ Nas horas vagas eu sou um namorado coruja de uma moça linda, colecionador de qu
 
 Mande um abraço para ele(a) no email msfidelis01@gmail.com ou no Twitter.
 
-## Mentorados
+## Mentorados(as)
 
 - [Igor Oliveira](/profiles/pupils/profiles/IgoOliveira.md) - [Projeto prático da mentoria](https://github.com/devigor/mentoria-devops)

--- a/profiles/mentors/profiles/matheus_marsiglio.md
+++ b/profiles/mentors/profiles/matheus_marsiglio.md
@@ -22,7 +22,7 @@ estudo de forma autodidata campos da ciência da computação, arquitetura de so
 
 Mande um upa para matmarsiglio@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 * [Luan Vicente](/profiles/pupils/profiles/luan_vicente.md)
 * [Luiz Lázaro](/profiles/pupils/profiles/LuizLazaro.md)

--- a/profiles/mentors/profiles/matheus_marsiglio.md
+++ b/profiles/mentors/profiles/matheus_marsiglio.md
@@ -22,7 +22,7 @@ estudo de forma autodidata campos da ciência da computação, arquitetura de so
 
 Mande um upa para matmarsiglio@gmail.com ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 * [Luan Vicente](/profiles/pupils/profiles/luan_vicente.md)
 * [Luiz Lázaro](/profiles/pupils/profiles/LuizLazaro.md)

--- a/profiles/mentors/profiles/mikaelhadler.md
+++ b/profiles/mentors/profiles/mikaelhadler.md
@@ -12,11 +12,10 @@ Mentor para Desenvolvedores Front End e opensource life style.
 * [Twitter](https://twitter.com/mikaelhadler)
 * [LinkedIn](https://www.linkedin.com/in/mikaelhadler)
 
-## Mentorados
+## Mentorados(as)
 
 - [Matheus Mazeto](https://github.com/training-center/mentoria/blob/master/profiles/pupils/profiles/matheus_mazeto.md)
 
 ## Gostaria de retribuir a ajuda do(a) [Mikael Hadler]?
 
 Abra uma issue em [seus repositório](https://github.com/mikaelhadler?tab=repositories), mande um abraço para ele(a) no email mikaelhadler@gmail.com ou nas redes sociais.
-

--- a/profiles/mentors/profiles/mikaelhadler.md
+++ b/profiles/mentors/profiles/mikaelhadler.md
@@ -12,7 +12,8 @@ Mentor para Desenvolvedores Front End e opensource life style.
 * [Twitter](https://twitter.com/mikaelhadler)
 * [LinkedIn](https://www.linkedin.com/in/mikaelhadler)
 
-## Pupilos
+## Mentorados
+
 - [Matheus Mazeto](https://github.com/training-center/mentoria/blob/master/profiles/pupils/profiles/matheus_mazeto.md)
 
 ## Gostaria de retribuir a ajuda do(a) [Mikael Hadler]?

--- a/profiles/mentors/profiles/paulo_diniz.md
+++ b/profiles/mentors/profiles/paulo_diniz.md
@@ -21,7 +21,7 @@ Sempre disponível para ajudar
 Ainda não defini uma instituição de preferência, mas se você gostou de qualquer ajuda que eu forneci e tem condição de ajudar outras pessoas,
 por favor considere doar para uma instituição de caridade.
 
-## Pupilos
+## Mentorados
 
 * Leonardo L. Sousa
 * [Jamile Lima](/profiles/pupils/profiles/JamileLima.md)

--- a/profiles/mentors/profiles/paulo_diniz.md
+++ b/profiles/mentors/profiles/paulo_diniz.md
@@ -21,7 +21,7 @@ Sempre disponível para ajudar
 Ainda não defini uma instituição de preferência, mas se você gostou de qualquer ajuda que eu forneci e tem condição de ajudar outras pessoas,
 por favor considere doar para uma instituição de caridade.
 
-## Mentorados
+## Mentorados(as)
 
 * Leonardo L. Sousa
 * [Jamile Lima](/profiles/pupils/profiles/JamileLima.md)

--- a/profiles/mentors/profiles/rafael_koga.md
+++ b/profiles/mentors/profiles/rafael_koga.md
@@ -28,4 +28,4 @@ CVC, Serasa Experian, ITAU e EY
 
 Mande um abraço para ele no email rafaelkoga@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/rafael_koga.md
+++ b/profiles/mentors/profiles/rafael_koga.md
@@ -28,4 +28,4 @@ CVC, Serasa Experian, ITAU e EY
 
 Mande um abraço para ele no email rafaelkoga@gmail.com ou nas redes sociais.
 
-## Pupilos de Rafael Koga
+## Mentorados

--- a/profiles/mentors/profiles/raymonsanches.md
+++ b/profiles/mentors/profiles/raymonsanches.md
@@ -21,6 +21,6 @@ Quero ser mentor pra ajudar principalmente quem está iniciando na carreira com 
 
 Mande um tweet, apareça num meetup, mande um emoji e tamo junto!
 
-## Pupilos do Ramon Sanches
+## Mentorados
 
 Nenhum :(

--- a/profiles/mentors/profiles/raymonsanches.md
+++ b/profiles/mentors/profiles/raymonsanches.md
@@ -21,6 +21,6 @@ Quero ser mentor pra ajudar principalmente quem está iniciando na carreira com 
 
 Mande um tweet, apareça num meetup, mande um emoji e tamo junto!
 
-## Mentorados
+## Mentorados(as)
 
 Nenhum :(

--- a/profiles/mentors/profiles/reinaldo_oliveira.md
+++ b/profiles/mentors/profiles/reinaldo_oliveira.md
@@ -34,6 +34,6 @@ serem adotados.
 
 Mande um tweet, me add no LinkedIn!
 
-## Pupilos do Reinaldo Oliveira
+## Mentorados
 
 Nenhum :(

--- a/profiles/mentors/profiles/reinaldo_oliveira.md
+++ b/profiles/mentors/profiles/reinaldo_oliveira.md
@@ -34,6 +34,6 @@ serem adotados.
 
 Mande um tweet, me add no LinkedIn!
 
-## Mentorados
+## Mentorados(as)
 
 Nenhum :(

--- a/profiles/mentors/profiles/renan_oliveira.md
+++ b/profiles/mentors/profiles/renan_oliveira.md
@@ -17,6 +17,6 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço para ele no [email](mailto:renansdeoliveira@gmail.com) ou deixe sua recomendação no [LinkedIn](https://linkedin.com/in/renanoliver).
 
-## Mentorados
+## Mentorados(as)
 
 * [Jamile Lima](/profiles/pupils/profiles/JamileLima.md)

--- a/profiles/mentors/profiles/renan_oliveira.md
+++ b/profiles/mentors/profiles/renan_oliveira.md
@@ -17,6 +17,6 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço para ele no [email](mailto:renansdeoliveira@gmail.com) ou deixe sua recomendação no [LinkedIn](https://linkedin.com/in/renanoliver).
 
-## Pupilos de Renan Oliveira
+## Mentorados
 
 * [Jamile Lima](/profiles/pupils/profiles/JamileLima.md)

--- a/profiles/mentors/profiles/rubens_nascimento.md
+++ b/profiles/mentors/profiles/rubens_nascimento.md
@@ -24,4 +24,4 @@ Gosto muito de lecionar e espero que possa ajudar diversas pessoas :)
 
 Manda um "olá" pelas redes sociais ou pelo e-mail.
 
-## Pupilos do Rubens Pereira do Nascimento
+## Mentorados

--- a/profiles/mentors/profiles/rubens_nascimento.md
+++ b/profiles/mentors/profiles/rubens_nascimento.md
@@ -24,4 +24,4 @@ Gosto muito de lecionar e espero que possa ajudar diversas pessoas :)
 
 Manda um "olá" pelas redes sociais ou pelo e-mail.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/thiago_paes.md
+++ b/profiles/mentors/profiles/thiago_paes.md
@@ -18,7 +18,7 @@ Mentor para Desenvolvedores Front End, Back End e Full Stack
 
 Escreva software livre, publique código aberto.. contribua com a comunidade. Um "obrigado" também já basta :)
 
-## Pupilos do Thiago Paes
+## Mentorados
 
 * [Gustavo Aguiar](/profiles/pupils/profiles/GustavoAguiar.md)
 * [Frederico Xavier Drumond](/profiles/pupils/profiles/fredrumond.md)

--- a/profiles/mentors/profiles/thiago_paes.md
+++ b/profiles/mentors/profiles/thiago_paes.md
@@ -18,7 +18,7 @@ Mentor para Desenvolvedores Front End, Back End e Full Stack
 
 Escreva software livre, publique código aberto.. contribua com a comunidade. Um "obrigado" também já basta :)
 
-## Mentorados
+## Mentorados(as)
 
 * [Gustavo Aguiar](/profiles/pupils/profiles/GustavoAguiar.md)
 * [Frederico Xavier Drumond](/profiles/pupils/profiles/fredrumond.md)

--- a/profiles/mentors/profiles/vanildo_souto.md
+++ b/profiles/mentors/profiles/vanildo_souto.md
@@ -21,4 +21,4 @@ Mentor para Desenvolvedores  Backend PHP
 
 Mande um abraço para ele no email vanildo.souto@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)

--- a/profiles/mentors/profiles/vanildo_souto.md
+++ b/profiles/mentors/profiles/vanildo_souto.md
@@ -21,4 +21,4 @@ Mentor para Desenvolvedores  Backend PHP
 
 Mande um abraço para ele no email vanildo.souto@gmail.com ou nas redes sociais.
 
-## Pupilos Vanildo Souto Mangueira
+## Mentorados

--- a/profiles/mentors/profiles/vinicius_alonso.md
+++ b/profiles/mentors/profiles/vinicius_alonso.md
@@ -21,5 +21,5 @@ Mentor para desenvolvedores (as) focados (as) em qualidade de código, testes e 
 
 Basta seguir nas redes socias e mandar um abraço.
 
-## Pupilos de Vinicius
+## Mentorados
 - [Odilton Junior](/profiles/pupils/profiles/odilton_junior.md)

--- a/profiles/mentors/profiles/vinicius_alonso.md
+++ b/profiles/mentors/profiles/vinicius_alonso.md
@@ -21,5 +21,6 @@ Mentor para desenvolvedores (as) focados (as) em qualidade de código, testes e 
 
 Basta seguir nas redes socias e mandar um abraço.
 
-## Mentorados
+## Mentorados(as)
+
 - [Odilton Junior](/profiles/pupils/profiles/odilton_junior.md)

--- a/profiles/mentors/profiles/vinicius_reis.md
+++ b/profiles/mentors/profiles/vinicius_reis.md
@@ -24,7 +24,7 @@ Atualmente trabalho como Engenheiro de aplicações na [decision6](https://decis
 
 Mande um abraço para ele no email luiz.vinicius73@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 * [Emanuel Gonçalves](/profiles/pupils/profiles/EmanuelG.md)
 * [Daniel Diniz](/profiles/pupils/profiles/DanielDiniz.md)

--- a/profiles/mentors/profiles/vinicius_reis.md
+++ b/profiles/mentors/profiles/vinicius_reis.md
@@ -24,7 +24,7 @@ Atualmente trabalho como Engenheiro de aplicações na [decision6](https://decis
 
 Mande um abraço para ele no email luiz.vinicius73@gmail.com ou nas redes sociais.
 
-## Pupilos do Vinicius Reis
+## Mentorados
 
 * [Emanuel Gonçalves](/profiles/pupils/profiles/EmanuelG.md)
 * [Daniel Diniz](/profiles/pupils/profiles/DanielDiniz.md)

--- a/profiles/mentors/profiles/vinicius_tinguan.md
+++ b/profiles/mentors/profiles/vinicius_tinguan.md
@@ -20,6 +20,6 @@ Mentor para desenvolvedores Back-end
 Faça uma doação pra alguma causa animal ou de crianças carentes.  
 Ou me manda um alô nas redes sociais. :)
 
-## Pupilos do Vinicius
+## Mentorados
 
 [Hiran Neri](/profiles/pupils/profiles/HiranNeri.md)

--- a/profiles/mentors/profiles/vinicius_tinguan.md
+++ b/profiles/mentors/profiles/vinicius_tinguan.md
@@ -20,6 +20,6 @@ Mentor para desenvolvedores Back-end
 Faça uma doação pra alguma causa animal ou de crianças carentes.  
 Ou me manda um alô nas redes sociais. :)
 
-## Mentorados
+## Mentorados(as)
 
 [Hiran Neri](/profiles/pupils/profiles/HiranNeri.md)

--- a/profiles/mentors/profiles/wagner_santos.md
+++ b/profiles/mentors/profiles/wagner_santos.md
@@ -28,7 +28,7 @@ Vivo em constante atualização, sempre antenado com o que está acontecendo na 
 
 Mande um oi para contato@wagnersantos.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Luiz Gabriel Silva de Araujo](/profiles/pupils/profiles/luizgabriell.md)
 - [Rafael Martins dos Santos](/profiles/pupils/profiles/rafaelmartinsja.md)

--- a/profiles/mentors/profiles/wagner_santos.md
+++ b/profiles/mentors/profiles/wagner_santos.md
@@ -28,7 +28,7 @@ Vivo em constante atualização, sempre antenado com o que está acontecendo na 
 
 Mande um oi para contato@wagnersantos.com ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 - [Luiz Gabriel Silva de Araujo](/profiles/pupils/profiles/luizgabriell.md)
 - [Rafael Martins dos Santos](/profiles/pupils/profiles/rafaelmartinsja.md)

--- a/profiles/mentors/profiles/wendell_adriel.md
+++ b/profiles/mentors/profiles/wendell_adriel.md
@@ -42,7 +42,7 @@ Gosto de trabalhar com desenvolvimento Front-end e Back-end. Trabalho com divers
 
 Entre em contato pelo e-mail wendelladriel.ti@gmail.com ou wendell@codeshare.com.br ou pelas redes sociais!!!
 
-## Mentorados
+## Mentorados(as)
 
 - [Giovanni Cruz (giovannicruz97)](/profiles/pupils/profiles/giovannicruz97.md)
 - [Danilo Agostinho (DaniloAgostinho)](/profiles/pupils/profiles/DaniloAgostinho.md)

--- a/profiles/mentors/profiles/wendell_adriel.md
+++ b/profiles/mentors/profiles/wendell_adriel.md
@@ -42,7 +42,7 @@ Gosto de trabalhar com desenvolvimento Front-end e Back-end. Trabalho com divers
 
 Entre em contato pelo e-mail wendelladriel.ti@gmail.com ou wendell@codeshare.com.br ou pelas redes sociais!!!
 
-## Pupilos
+## Mentorados
 
 - [Giovanni Cruz (giovannicruz97)](/profiles/pupils/profiles/giovannicruz97.md)
 - [Danilo Agostinho (DaniloAgostinho)](/profiles/pupils/profiles/DaniloAgostinho.md)

--- a/profiles/mentors/profiles/wesley_queiroz.md
+++ b/profiles/mentors/profiles/wesley_queiroz.md
@@ -25,7 +25,7 @@ Tenho conhecimentos variados e posso tentar auxiliar em tecnologias como:
 - Outras linguagens de back-end como Ruby, Python, ASP.Net, PHP; porém não me garanto em nenhuma e nem tenho orgulho das últimas duas mencinadas (rsrs).
 - Bancos de dados relacionais e não relacionais como MySQL, Postgres, Sqlite, MongoDB, Redis, Elastic Search, CouchDB, MemcacheDB e IndexedDB (no navegador).
 
-## Meus pupilos
+## Meus mentorados
 
 - [Gabrielle Dias](/profiles/pupils/profiles/GabrielleDias.md)
 - [Genor Chiomento](/profiles/pupils/profiles/GenorChiomento.md)

--- a/profiles/mentors/profiles/wesley_queiroz.md
+++ b/profiles/mentors/profiles/wesley_queiroz.md
@@ -25,7 +25,7 @@ Tenho conhecimentos variados e posso tentar auxiliar em tecnologias como:
 - Outras linguagens de back-end como Ruby, Python, ASP.Net, PHP; porém não me garanto em nenhuma e nem tenho orgulho das últimas duas mencinadas (rsrs).
 - Bancos de dados relacionais e não relacionais como MySQL, Postgres, Sqlite, MongoDB, Redis, Elastic Search, CouchDB, MemcacheDB e IndexedDB (no navegador).
 
-## Meus mentorados
+## Mentorados(as)
 
 - [Gabrielle Dias](/profiles/pupils/profiles/GabrielleDias.md)
 - [Genor Chiomento](/profiles/pupils/profiles/GenorChiomento.md)

--- a/profiles/mentors/profiles/william_bruno.md
+++ b/profiles/mentors/profiles/william_bruno.md
@@ -20,7 +20,7 @@ William Bruno é desenvolvedor web apaixonado por boas práticas e design patter
 
 Mande um abraço para ele no email wbrunom@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 * [Renê Soares](/profiles/pupils/profiles/renesoares.md)
 * [Gabriel Ferreira](/profiles/pupils/profiles/gabriel_ferreira.md)

--- a/profiles/mentors/profiles/william_bruno.md
+++ b/profiles/mentors/profiles/william_bruno.md
@@ -20,7 +20,7 @@ William Bruno é desenvolvedor web apaixonado por boas práticas e design patter
 
 Mande um abraço para ele no email wbrunom@gmail.com ou nas redes sociais.
 
-## Pupilos William Bruno
+## Mentorados
 
 * [Renê Soares](/profiles/pupils/profiles/renesoares.md)
 * [Gabriel Ferreira](/profiles/pupils/profiles/gabriel_ferreira.md)

--- a/profiles/mentors/profiles/william_oliveira.md
+++ b/profiles/mentors/profiles/william_oliveira.md
@@ -19,7 +19,7 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço no email williamozsouza@gmail.com com o assunto `#mentoria` ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 - [Gabriel Brito](/profiles/pupils/profiles/GabrielBrito.md)
 - [Lucas Stoque](/profiles/pupils/profiles/Stoque.md)

--- a/profiles/mentors/profiles/william_oliveira.md
+++ b/profiles/mentors/profiles/william_oliveira.md
@@ -19,7 +19,7 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço no email williamozsouza@gmail.com com o assunto `#mentoria` ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Gabriel Brito](/profiles/pupils/profiles/GabrielBrito.md)
 - [Lucas Stoque](/profiles/pupils/profiles/Stoque.md)

--- a/profiles/mentors/profiles/william_w_oliveira.md
+++ b/profiles/mentors/profiles/william_w_oliveira.md
@@ -19,7 +19,7 @@ Mentor para Desenvolvedores Front End e Back End (Full Stack)
 
 Mande um abraço para ele no email sudowilliam@gmail.com ou nas redes sociais.
 
-## Pupilos do William
+## Mentorados
 
 - [Bruno Martins](/profiles/pupils/profiles/Bruno_Martins.md)
 - [Celso Lopes](/profiles/pupils/profiles/CelsoLopes.md)

--- a/profiles/mentors/profiles/william_w_oliveira.md
+++ b/profiles/mentors/profiles/william_w_oliveira.md
@@ -19,7 +19,7 @@ Mentor para Desenvolvedores Front End e Back End (Full Stack)
 
 Mande um abraço para ele no email sudowilliam@gmail.com ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Bruno Martins](/profiles/pupils/profiles/Bruno_Martins.md)
 - [Celso Lopes](/profiles/pupils/profiles/CelsoLopes.md)

--- a/profiles/mentors/profiles/wilson_campos.md
+++ b/profiles/mentors/profiles/wilson_campos.md
@@ -22,9 +22,7 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço no email wilsoncampoz@outlook.com com o assunto `#mentoria` ou nas redes sociais.
 
-## Pupilos
+## Mentorados
 
 - [Allan Ramos](/profiles/pupils/profiles/AllanRamos.md)
 - [Mayara Pimentel](/profiles/pupils/profiles/mayarapimentel.md)
-
-

--- a/profiles/mentors/profiles/wilson_campos.md
+++ b/profiles/mentors/profiles/wilson_campos.md
@@ -22,7 +22,7 @@ Mentor para Desenvolvedores Front End
 
 Mande um abraço no email wilsoncampoz@outlook.com com o assunto `#mentoria` ou nas redes sociais.
 
-## Mentorados
+## Mentorados(as)
 
 - [Allan Ramos](/profiles/pupils/profiles/AllanRamos.md)
 - [Mayara Pimentel](/profiles/pupils/profiles/mayarapimentel.md)


### PR DESCRIPTION
Hello @training-center/mentors,

## **Esse _PR_ só deve ser aceito com a revisão de mais de uma pessoa!**

> A força tarefa não pode parar!

Alterei a maioria dos perfis dos `mentores` para que usem termo correto ao se referir aos `mentorados`.

Notas importantes:

- Percebi durante a atualização, que muitos dos perfis estão desatualizados, então fica aqui a nota: **Leiam o item três dos [termos de responsabilidade de cada mentor](https://github.com/training-center/mentoria/blob/master/profiles/pupils/responsibility.md)**
  - A sugestão para quem tem pouco tempo: Sugira aos `mentorados` que ao criarem o perfil, atualizem também o perfil do `mentor` adicionando-o a lista de `mentorados do mentor X`.

- Esse pull-request pode futuramente quebrar muitos *pull-requests* de mentores (mas isso é problema nosso, pois somos nós que administramos o que é aceito e se tiver erro, devemos corrigir)
  - Inclusive *pull-request* abertos no momento:  #788

- Removi coisas redundantes dos links como `Facebook do Mentor ...` passou a chamar apenas `Facebook`

Se houver alguma sugestão, estou aceitando, visto que estamos aqui para melhorar o repositório ;)