### PR TITLE
Alteração do termo -pupilo- na documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Nós esperamos que você leia esse documento sobre como funciona o projeto Mento
 - [Como funciona](#como-funciona)
 - [O que é um(a) Mentor(a)](#o-que-é-uma-mentora)
 - [Nossos Mentores(as)](#nossos-mentoresas)
-- [Nossos Pupilos(as)](#nossos-pupilosas)
+- [Nossos Mentorados(as)](#nossos-mentoradosas)
 - [Quero ser Mentor(a)](#quero-ser-mentora)
 - [Preciso de um(a) Mentor(a)](#preciso-de-uma-mentora)
 - [Regras de conduta](#regras-de-conduta)
@@ -79,7 +79,7 @@ Todos aqui envolvidos devem buscar ser auto-gerenciáveis e ambas as partes deve
 
 [Lista dos Mentores(as)](profiles/mentors)
 
-## Nossos Pupilos(as)
+## Nossos Mentorados(as)
 
 [Lista de quem já recebe ajuda de algum Mentor(a)](profiles/pupils)
 
@@ -95,11 +95,11 @@ Assim que o seu PR for analisado e aprovado pelos outros mentores e mentoras e a
 
 Você será avaliado(a) pelos(as) outros [mentores(as)](profiles/mentors) do projeto antes de poder participar, levando em conta sua experiência, perfil interpessoal, dentre [outros pontos](https://github.com/training-center/mentoria/issues/1). Porém não tenha medo, nossos maiores critérios são sua vontade de ajudar, como trata outras pessoas e disponibilidade.
 
-**Numero mínimo e máximo de pupilos(as)**
+**Numero mínimo e máximo de mentorados(as)**
 
 Cada mentor(a) deverá ajudar entre [1 até, **no máximo**, 10 pessoas](https://github.com/training-center/mentoria/issues/2), dependendo de sua disponibilidade, disposição, etc.
 
-É de extrema importância que você nos informe, sempre, se está tendo problemas com o(a) pupilo(a) e para isso você pode entrar em contato com qualquer [moderador](admin/MODERATORS.md) ou pelo [Slack](https://ctgroups.herokuapp.com/) ou avisar em nosso grupo privado no [Telegram](https://telegram.me/).
+É de extrema importância que você nos informe, sempre, se está tendo problemas com o(a) mentorado(a) e para isso você pode entrar em contato com qualquer [moderador](admin/MODERATORS.md) ou pelo [Slack](https://ctgroups.herokuapp.com/) ou avisar em nosso grupo privado no [Telegram](https://telegram.me/).
 
 Esse projeto **NÃO** tem fins lucrativos, por isso você **NÃO** pode cobrar para ser mentor(a) de nenhuma pessoa que pediu ajuda nesse repositório!
 
@@ -116,7 +116,7 @@ Aproveite para tirar algumas dúvidas no artigo ["Dicas para novos mentores(as)"
 1. Você abre um PR
 2. Os [mentores e mentoras](profiles/mentors) e [moderadores(as)](admin/MODERATORS.md) avaliam seu perfil
 3. Se seu perfil for aprovado, você vira mentor(a) e é convidado a entrar nessa ORG, no nosso [Slack](https://ctgroups.herokuapp.com/) e em nosso board no Trello
-4. Entre no nosso board no Trello para procurar candidatos a pupilos e pupilas e entrar em contato com eles
+4. Entre no nosso board no Trello para procurar candidatos a mentorados e mentoradas e entrar em contato com eles
 5. No board, de uma olhada nos cards que estão na primeira coluna, são os cards que lhe servirão de guia sobre como tudo funciona no nosso Trello
 
 A escolha por ajudar alguém deve partir de você com base nos seus critérios como tempo disponível para ajudar e tempo que a pessoa precisa de ajuda, skills que a pessoa busca e os que você possui, compatibilidade de personalidade com a pessoa, etc.
@@ -125,7 +125,7 @@ OBS: Caso esqueçamos de te adicionar a organização, entre em contato com os [
 
 ## Preciso de um(a) Mentor(a)
 
-Primeiro leia as [responsabilidades de um(a) pupilo(a)](profiles/pupils/responsibility.md) e veja se está de acordo com isso. Em seguida, basta responder [esse formulário](http://bit.ly/preciso-de-mentoria) e aguardar o contato de algum mentor ou mentora.
+Primeiro leia as [responsabilidades de um(a) mentorado(a)](profiles/pupils/responsibility.md) e veja se está de acordo com isso. Em seguida, basta responder [esse formulário](http://bit.ly/preciso-de-mentoria) e aguardar o contato de algum mentor ou mentora.
 
 Caso você tenha alguma dúvida quanto ao funcionamento do projeto, pode abrir uma issue aqui para esclarecimento ou perguntar no canal `#mentoria-project` no nosso [Slack](https://ctgroups.herokuapp.com/).
 
@@ -143,26 +143,26 @@ Se algum(a) Mentor(a) **COBRAR** para te ajudar, é de extrema importância que 
 
 É de sua responsabilidade a comunicação com seu(sua) mentor(a) para que haja continuidade no processo. Caso você não mantenha essa comunicação, os(as) mentores(as) podem lhe abandonar e partir para ajudar outra pessoa.
 
-Não se esqueça de ler as [Dicas para novos(as) pupilos(as)](https://medium.com/trainingcenter/dicas-para-novos-as-pupilos-as-3f82f6237e9a).
+Não se esqueça de ler as [Dicas para novos(as) mentorados(as)](https://medium.com/trainingcenter/dicas-para-novos-as-pupilos-as-3f82f6237e9a).
 
 **Resumindo**
 
 1. Você responde [nosso formulário](http://bit.ly/preciso-de-mentoria) e aguarda o contato de um mentor ou de uma mentora
 2. Se tudo deu certo, você poderá adicionar seu [perfil a lista](/profiles/pupils) seguindo o [template](profiles/pupils/pupil_template.md) e [absorver](./img/cell.png) a experiência do(a) seu/sua Mentor(a)
-3. Atualize o [README.md](/profiles/pupils/README.md) da pasta pupilos com o link para o seu perfil
+3. Atualize o [README.md](/profiles/pupils/README.md) da pasta mentorados com o link para o seu perfil
 4. Entre no nosso [Slack](https://ctgroups.herokuapp.com/) e avise sobre sua chegada
 
 OBS: Caso esqueçamos de te adicionar a organização, entre em contato com os [moderadores](admin/MODERATORS.md) ou pelo [Slack](https://ctgroups.herokuapp.com/)
 
 ## Regras de conduta
 
-Temos regras de conduta para o(a) **mentor(a)** e para o(a) **pupilo(a)**, leia as regras [aqui](admin/CONDUTA.md) antes de assumir qualquer responsabilidade.
+Temos regras de conduta para o(a) **mentor(a)** e para o(a) **mentorado(a)**, leia as regras [aqui](admin/CONDUTA.md) antes de assumir qualquer responsabilidade.
 
 ## Mantenha o contato conosco
 
-Durante o processo de auxílio ao pupilo(a) podem aparecer problemas como: abandono por parte do pupilo,  por parte do mentor ou mesmo mal convívio entre ambos. Caso algo esteja indo mal, avise-nos!
+Durante o processo de auxílio ao mentorado(a) podem aparecer problemas como: abandono por parte do mentorado,  por parte do mentor ou mesmo mal convívio entre ambos. Caso algo esteja indo mal, avise-nos!
 
-Precisamos que mentores(as) e pupilos(as) estejam no nosso [Slack](https://ctgroups.herokuapp.com/) para que haja comunicação entre organização e participantes/contribuintes, pois qualquer problema entre vocês deve ser tratado. Não queremos causar problemas para nenhuma das partes.
+Precisamos que mentores(as) e mentorados(as) estejam no nosso [Slack](https://ctgroups.herokuapp.com/) para que haja comunicação entre organização e participantes/contribuintes, pois qualquer problema entre vocês deve ser tratado. Não queremos causar problemas para nenhuma das partes.
 
 ## Desejo contribuir financeiramente
 

--- a/admin/ADMINS_GUIDE.md
+++ b/admin/ADMINS_GUIDE.md
@@ -27,8 +27,8 @@ Documentação de como funciona o fluxo do Mentoria (esse projeto).
 	- adicionamos a pessoa no nosso board no Trello
 	- enviamos um email de boas vindas com o conteúdo do nosso [email para novos mentores e mentoras](https://docs.google.com/document/d/1mBr5J5XXnH-3an3eQgMTXcqqATwunOi3cWn2B0Gj9L8/edit?usp=sharing)
 
-## Novos(as) pupilos(as)
+## Novos(as) mentorados(as)
 
-- devemos analisar se essa pessoa seguiu o guia de como criar o documento de novo(a) pupilo(a)
+- devemos analisar se essa pessoa seguiu o guia de como criar o documento de novo(a) mentorado(a)
 - se estiver tudo OK, faça um code review no GitHub como `aproved`
 - assim que o PR com o novo perfil for aceito por pelo menos uma pessoa da organização, então fazemos o merge e adicionamos a pessoa a nossa org

--- a/admin/CONDUTA.md
+++ b/admin/CONDUTA.md
@@ -2,20 +2,20 @@
 
 Essas são as regras de conduta, para que não aconteça nenhum transtorno por parte dos(as) envolvidos(as) no projeto.
 
-Tanto Mentores(as), quanto Pupilos(as), tem suas regras individuais sendo que temos as regras que se aplicam a ambos(as) no processo de mentoria.
+Tanto Mentores(as), quanto Mentorados(as), tem suas regras individuais sendo que temos as regras que se aplicam a ambos(as) no processo de mentoria.
 
 ## Mentor(a)
 
-* O(A) Mentor(a) não pode cobrar em dinheiro para ajudar o(a) Pupilo(a), mas o(a) Pupilo(a) pode doar para ele(a).
+* O(A) Mentor(a) não pode cobrar em dinheiro para ajudar o(a) Mentorado(a), mas o(a) Mentorado(a) pode doar para ele(a).
 Caso alguém relate a cobrança, devemos tomar medidas contra o(a) Mentor(a). Nesse caso acho justo expulsar o(a) mesmo(a) do projeto, afinal está bem claro que a ajuda não deve ser cobrada.
 * O(A) Mentor(a) não tem obrigação de entregar código ou solução pronta para dúvidas técnicas. Ele(a) deve orientar e ajudar a chegar na solução ideal para um problema.
-* O(A) Mentor(a) irá avaliar o desempenho do Pupilo(a) e caso o(a) mesmo(a) não demonstre disposição para com as dicas do Mentor(a), o(a) mesmo(a) pode abandonar o Pupilo(a) e pegar outro(a) que esteja na fila.
+* O(A) Mentor(a) irá avaliar o desempenho do Mentorado(a) e caso o(a) mesmo(a) não demonstre disposição para com as dicas do Mentor(a), o(a) mesmo(a) pode abandonar o Mentorado(a) e pegar outro(a) que esteja na fila.
 
-## Pupilo(a)
+## Mentorado(a)
 
-* O(A) Pupilo(a) não deve cobrar disponibilidade 24hs, 7 dias por semana do seu Mentor(a), afinal o(a) mesmo(a) possui vida fora desse projeto e o projeto é só uma ajuda para a comunidade.
-* O(A) Pupilo(a) deve nos avisar, imediatamente, caso um(a) Mentor(a) venha cobrar financeiramente por sua mentoria.
-* O(A) Pupilo(a) deve demonstrar disposição para com as dicas do Mentor(a), caso não concorde com o ponto de vista do(a) mesmo(a) com relação a algo, pode dialogar - isso é bom -, mas o abandono, falta de compromisso ou qualquer atitude que demonstre falta de vontade por parte do Pupilo(a), poderá acarretar em abandono por parte do(a) Mentor(a) e liberação de sua vaga para outra pessoa.
+* O(A) Mentorado(a) não deve cobrar disponibilidade 24hs, 7 dias por semana do seu Mentor(a), afinal o(a) mesmo(a) possui vida fora desse projeto e o projeto é só uma ajuda para a comunidade.
+* O(A) Mentorado(a) deve nos avisar, imediatamente, caso um(a) Mentor(a) venha cobrar financeiramente por sua mentoria.
+* O(A) Mentorado(a) deve demonstrar disposição para com as dicas do Mentor(a), caso não concorde com o ponto de vista do(a) mesmo(a) com relação a algo, pode dialogar - isso é bom -, mas o abandono, falta de compromisso ou qualquer atitude que demonstre falta de vontade por parte do Mentorado(a), poderá acarretar em abandono por parte do(a) Mentor(a) e liberação de sua vaga para outra pessoa.
 
 ## Responsabilidade de ambas as partes
 

--- a/admin/MODERATORS.md
+++ b/admin/MODERATORS.md
@@ -5,4 +5,3 @@
 - [Matheus Marsiglio](https://github.com/matmarsiglio)
 - [Ramon Sanches](https://github.com/raymonsanches)
 - [William Oliveira](https://github.com/woliveiras)
-

--- a/admin/helpers/CREATE_PUPIL_PROFILE.md
+++ b/admin/helpers/CREATE_PUPIL_PROFILE.md
@@ -1,6 +1,6 @@
-# Como criar o perfil de Pupilo
+# Como criar o perfil de Mentorado
 
-Acesse o endereço dos perfis de Pupilos, [aqui](https://github.com/training-center/mentoria/tree/master/pupilos/perfis).
+Acesse o endereço dos perfis dos Mentorados, [aqui](https://github.com/training-center/mentoria/tree/master/profiles/pupils).
 
 E clique em `Create new file`.
 
@@ -12,25 +12,25 @@ Em seguida coloque o nome do arquivo como **seu_nome_de_usuario_do_github**.md -
 
 Não se esqueça do **.md** que é a extensão para Markdown.
 
-Agora você pode copiar o conteúdo do template, [aqui](/pupilos/pupilo_template.md), e modificar onde devem ir os seus dados.
+Agora você pode copiar o conteúdo do template, [aqui](https://github.com/training-center/mentoria/blob/master/profiles/pupils/pupil_template.md), e modificar onde devem ir os seus dados.
 
-![Template de perfil de pupilo](/img/pupil-template-helper.png)
+![Template de perfil de mentorado](/img/pupil-template-helper.png)
 
 Em seguida basta criar o commit para esse arquivo.
 
 ![Criando o commit para o arquivo](/img/commit-with-new-profile-helper.png)
 
-Agora adicione a referência ao seu perfil na [lista de pupilos](/pupilos/README.md), clicando em `Edit this file`.
+Agora adicione a referência ao seu perfil na [lista de mentorados](https://github.com/training-center/mentoria/blob/master/profiles/pupils/README.md), clicando em `Edit this file`.
 
 ![Botão Edit this file](/img/edit-this-file-button-helper.png)
 
 Adicione seu nome **em ordem alfabética**.
 
-![Adicionando o nome do pupilo na lista de pupilos](/img/add-pupil-profile-in-readme-helper.png)
+![Adicionando o nome do mentorado na lista de mentorados](/img/add-pupil-profile-in-readme-helper.png)
 
 Depois é só criar o commit.
 
-![Commit no README.md da lista de pupilos](/img/commit-readme-helper.png)
+![Commit no README.md da lista de mentorados](/img/commit-readme-helper.png)
 
 Volte na raiz do projeto, no seu fork (o GitHub fez um fork automaticamente quando você clicou em "Create new file" no primeiro passo desse tutorial) e clicar em `New Pull Request`.
 

--- a/admin/helpers/README.md
+++ b/admin/helpers/README.md
@@ -1,10 +1,9 @@
-# Criando/Atualizando perfis de mentor e pupilo
+# Criando/Atualizando perfis de mentor e mentorado
+
+A criação e atualização de perfis de mentores(as) e mentorados é muito importante para mantermos uma boa comunicação entre organização e participantes dos projetos do Training Center.
 
 
-A criação e atualização de perfis de mentores(as) e pupilos é muito importante para mantermos uma boa comunicação entre organização e participantes dos projetos do Training Center.
-
-
-Os(As) mentores(as) são adicionadas no grupo `mentors` e os pupilos no grupo `pupils` aqui no GitHub para que recebam notificações quando seus grupos forem mencionados em issues.
+Os(As) mentores(as) são adicionadas no grupo `mentors` e os mentorados no grupo `pupils` aqui no GitHub para que recebam notificações quando seus grupos forem mencionados em issues.
 
 
 Ex.: [#150](https://github.com/training-center/mentoria/issues/150), [#151](https://github.com/training-center/mentoria/issues/151)
@@ -14,7 +13,7 @@ Ex.: [#150](https://github.com/training-center/mentoria/issues/150), [#151](http
 
 
 - [mentor](CREATE_MENTOR_PROFILE.md)
-- [pupilo](CREATE_PUPIL_PROFILE.md)
+- [mentorado](CREATE_PUPIL_PROFILE.md)
 
 
 Lembre-se de avisar os [moderadores](/MODERATORS.md) que você criou seu perfil para adicionarmos seu usuário na nossa organização e, se for mentor(a), no nosso canal de mentores no [Slack](https://ctgroups.herokuapp.com/) caso isso não aconteça quando fizermos o merge das suas alterações no projeto.
@@ -23,4 +22,4 @@ Lembre-se de avisar os [moderadores](/MODERATORS.md) que você criou seu perfil 
 OBS: Sua presença no [Slack](https://ctgroups.herokuapp.com/) é muito importante para mantermos você atualizado(a) sobre o projeto.
 
 
-**O(A) mentor(a) e pupilo são os responsáveis por manter os dados atualizados.**
+**O(A) mentor(a) e mentorado são os responsáveis por manter os dados atualizados.**

--- a/profiles/mentors/mentor_template.md
+++ b/profiles/mentors/mentor_template.md
@@ -24,9 +24,9 @@ Seu perfil profissional e alguma informação sobre você
 
 [Link para o PayPal, PagSeguro, etc](link) ou mande um abraço para ele(a) no email xxx@xxx.com ou nas redes sociais.
 
-## Pupilos de [Seu nome]
+## Mentorados(as)
 
-* [Pupilo 1](/profiles/pupils/profiles/pupilo1.md)
-* [Pupilo 2](/profiles/pupils/profiles/pupilo2.md)
-* [Pupilo 3](/profiles/pupils/profiles/pupilo3.md)
+* [Mentorado 1](/profiles/pupils/profiles/mentorado1.md)
+* [Mentorado 2](/profiles/pupils/profiles/mentorado2.md)
+* [Mentorado 3](/profiles/pupils/profiles/mentorado3.md)
 ```

--- a/profiles/mentors/responsibility.md
+++ b/profiles/mentors/responsibility.md
@@ -5,6 +5,6 @@ Como Mentor(a):
 * Você deve seguir o [código de conduta](/admin/CONDUTA.md)
 * Você deve criar seu [perfil](/profiles/mentors) nesse repositório seguindo o [template](/profiles/mentors/mentor_template.md)
 * Você precisa manter seu perfil atualizado
-* Você precisa garantir que o(a) pupilo(a) atualize o [perfil](/profiles/pupils) dele(a) seguindo o [template](/profiles/pupils/pupil_template.md)
+* Você precisa garantir que o(a) mentorado(a) atualize o [perfil](/profiles/pupils) dele(a) seguindo o [template](/profiles/pupils/pupil_template.md)
 * Você deve estar no nosso [Telegram](https://telegram.me) para receber avisos, discutir ideias, etc
 * Você deve estar no nosso board no [Trello](https://trello.com) para conseguir contato de quem precisa de ajuda

--- a/profiles/pupils/README.md
+++ b/profiles/pupils/README.md
@@ -1,4 +1,4 @@
-# Lista de Pupilos
+# Lista de Mentorados
 
 - [Adelmo Junior](profiles/AdelmoJunior.md)
 - [Adeonir Kohl](profiles/AdeonirKohl.md)

--- a/profiles/pupils/profiles/MarceloHenrique.md
+++ b/profiles/pupils/profiles/MarceloHenrique.md
@@ -16,9 +16,8 @@ HTML, CSS, Javascript básico faço tutoriais mais quando é para fazer algo do 
 
 ## Alguns links para me conhecer melhor
 
-[Facebook do Marcelo Henrique](https://www.facebook.com/maassilva)
-[Twitter do Marcelo Henrique](https://twitter.com/marcelossilva)
-[LinkedIn do Pupilo de Castro](https://www.linkedin.com/in/cvmarcelosilva)
-[Github do Marcelo Henrique](https://github.com/Marcelosilva10)
-[Codepen do Marcelo Henrique](https://codepen.io/marcelossilva)
-```
+- [Facebook](https://www.facebook.com/maassilva)
+- [Twitter](https://twitter.com/marcelossilva)
+- [LinkedIn](https://www.linkedin.com/in/cvmarcelosilva)
+- [Github](https://github.com/Marcelosilva10)
+- [Codepen](https://codepen.io/marcelossilva)

--- a/profiles/pupils/profiles/luizgabriell.md
+++ b/profiles/pupils/profiles/luizgabriell.md
@@ -13,7 +13,7 @@ Meu sonho é aprender a criar sistemas úteis desdo zero para ajudar as pessoas 
 
 # Conhecimentos
 
-Sou literalmente um pupilo que conhece muito pouco (até mesmo quase nada) sobre o assunto e está em busca de lições e aprendizado.
+Sou literalmente um mentorado que conhece muito pouco (até mesmo quase nada) sobre o assunto e está em busca de lições e aprendizado.
 Atualmente só conheço linguagens de marcação (HTML e CSS), pouqussímo de C e um pouco de SQL Developer.
 Espero deixar esta lista  de conhecimentos mais extensa muito em breve. :) 
 

--- a/profiles/pupils/pupil_template.md
+++ b/profiles/pupils/pupil_template.md
@@ -1,6 +1,6 @@
-# Template de perfil de Pupilo(a)
+# Template de perfil de Mentorado(a)
 
-Template para cadastramento de perfis dos Pupilos(as).
+Template para cadastramento de perfis dos Mentorados(as).
 
 ```
 # Mentor(a) responsável por mim

--- a/profiles/pupils/pupil_template.md
+++ b/profiles/pupils/pupil_template.md
@@ -23,5 +23,5 @@ Adicione qual seu sonho de carreira aqui.
 
 - [LinkedIn](link)
 
-- [Email](email)
+- [Email](mailto:seu@email.com)
 ```

--- a/profiles/pupils/responsibility.md
+++ b/profiles/pupils/responsibility.md
@@ -1,6 +1,6 @@
-# Responsabilidades do Pupilo
+# Responsabilidades do Mentorado
 
-Como Pupilo:
+Como Mentorado:
 
 * Você deve seguir o [código de conduta](/admin/CONDUTA.md)
 * Você deve criar seu [perfil](/pupils) nesse repositório seguindo o [template](/profiles/pupils/pupil_template.md)
@@ -9,6 +9,6 @@ Como Pupilo:
 
 *Observações*
 
-**1:** Caso você passe duas semanas sem atualizar seu(sua) Mentor(a), ele(a) poderá "abandonar" o trabalho contigo e mudar para outro(a) pupilo(a).
+**1:** Caso você passe duas semanas sem atualizar seu(sua) Mentor(a), ele(a) poderá "abandonar" o trabalho contigo e mudar para outro(a) mentorado(a).
 Se você precisar se ausentar por algum tempo, pode avisar seu(sua) Mentor(a), então não precisará enviar o email.
 O importante é manter a comunicação entre vocês.


### PR DESCRIPTION
Hello @training-center/mentors,

## **Esse _PR_ só deve ser aceito com a revisão de mais de uma pessoa!**

> A força tarefa não pode parar!

Alterei a maioria dos lugares onde utilizávamos o termo `pupilo` para `mentorado`.

Notas importantes:

- O diretório `mentoria/profiles/pupils/` ainda existe e resolvi não alterar o nome, visto a quantidade de links, tanto interno, quanto externos (cito principalmente: `medium`) que fazem referência a tal diretório, todavia se for necessário podemos/devemos alterar!

- Algumas imagens listadas `mentoria/img/`, não serão fieis a documentação após o aceite desse _PR_, visto que os prints exibem coisas do tipo: `... pupilo ...` e na documentação teremos `... mentorado ...`, então a sugestão seria alterar as imagens (prints novos).

### **Esse _PR_ está completamente interligado com o #790**

Se houver alguma sugestão, estou aceitando, visto que estamos aqui para melhorar o repositório ;)