### PR TITLE
Add Lucas Stoque in mentors list

### DIFF
--- a/mentors-list.md
+++ b/mentors-list.md
@@ -4,3 +4,4 @@
 | --- | --- | --- | --- |
 | [William Oliveira](https://twitter.com/w_oliveiras) | FRONT-END e NodeJS | --- | :snowflake: |
 | [Clayton Silva](https://github.com/claytonsilva) | INFRA (DEVOPS) | TELEGRAM | @claytonssilva |
+| [Lucas Stoque](https://github.com/stoque) | FRONT-END | TELEGRAM | @lucstoque |


### PR DESCRIPTION
Adicione as seguintes informações neste pull request:

## Objetivos deste PR
Adicionar Lucas Stoque na lista de mentores

## O que foi alterado
mentors-list.md

## Como validar
N/A

Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](https://github.com/training-center/mentoria/.github/mentor-list.template.md)
