### PR TITLE
Ajustado o link do template de PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ Adicione as seguintes informações neste pull request:
 
 ## Como validar
 
-Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](.github/mentor-list.template.md)
+Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](mentor-list.template.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ Adicione as seguintes informações neste pull request:
 
 ## Como validar
 
-Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](https://github.com/training-center/mentoria/.github/mentor-list.template.md)
+Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](https://github.com/training-center/mentoria/blob/master/.github/mentor-list.template.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ Adicione as seguintes informações neste pull request:
 
 ## Como validar
 
-Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](https://github.com/training-center/mentoria/blob/master/.github/mentor-list.template.md)
+Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](.github/mentor-list.template.md)


### PR DESCRIPTION
Os links do Github não funcionam sem o path `blob`

Adicione as seguintes informações neste pull request:

## Objetivos deste PR

Corrigir um link quebrado

## O que foi alterado

Link do template

## Como validar

Abrir o link atual e o link ajustado, clicando em `Preview`

Caso você esteja se cadastrando como mentor ou mentora, certifique-se de ter seguido o template para a lista de mentores(as): [template](https://github.com/training-center/mentoria/.github/mentor-list.template.md)
