### PR TITLE
lista de mentores 2.0

### DIFF
--- a/.github/mentor-list.template.md
+++ b/.github/mentor-list.template.md
@@ -2,7 +2,7 @@
 
 Adicione seu nome ao início da lista de mentores(as).
 
-**A lista não é ordenada alfabéticamente, mas por ordem de chegada. O último mentor ou a última mentora a entrar no projeto fica no começo da lista (como uma pilha).**
+**IMPORTANTE: A lista não é ordenada alfabéticamente, mas por ordem de chegada. O último mentor ou a última mentora a entrar no projeto fica no começo da lista (como uma pilha).**
 
 Isso porque a pessoa que procura mentoria irá entrar em contato com a primeira pessoa que encontrar com o perfil relacionado a sua carreira, sempre de cima para baixo, visto que o comportamento padrão das pessoas é lerem uma lista do começo ao fim. Então os primeiros mentores e mentoras que entraram no projeto não serão sobrecarregados(as) de pedidos de ajuda.
 
@@ -10,48 +10,48 @@ Você pode deixar um link em seu nome com alguma rede social para a pessoa te co
 
 Por exemplo:
 
-| NOME | TIPO DE MENTORIA | MEIO DE CONTATO | CONTATO
-| --- | --- | --- | --- |
-| [William Oliveira](https://twitter.com/w_oliveiras) | Front-End e Nodejs | TELEGRAM | @meutelegram
+| NOME | TIPO DE MENTORIA | CONTATO |
+| :--- | :--- | :---: |
+| [William Oliveira](https://twitter.com/w_oliveiras) | FRONT-END / NODEJS | [@woliveiras](https://telegram.me/woliveiras) |
 
-## Possíveis meios de contato
+**Explicação das colunas**
 
-| MEIO DE CONTATO
-| --
-| TELEGRAM
-| SLACK
+* na coluna **NOME** fica seu nome e um link para a pessoa conhecer você e/ou seu trabalho;
+* na coluna **TIPO DE MENTORIA** fica uma ou mais *badges* indicando em que você pode ajudar as pessoas. Abaixo falamos mais sobre as *badges*. 
+* na coluna **CONTATO** você vai colocar `[@seu_nick](seu_link_de_contato)`. Se preferir, você pode adicionar vários meios de contato, mas sempre separando-os com uma `/` (barra).
 
-Se for pelo Slack de outra comunidade, colocar o link para a pessoa entrar lá.
+**IMPORTANTE: Não adicione seu número de telefone ou e-mail como meio de contato.**
 
-**Não adicione seu número de telefone nesta lista.**
-
-## Tipos de mentoria
+## Tipos de mentoria (badges)
 
 Para facilitar a vida das pessoas que buscam mentoria, adicione pelo menos um desses badges ao seu tipo de mentoria:
 
-| TIPO DE MENTORIA 
-| --
-| FRONT-END
-| BACK-END
-| FULL-STACK
-| MOBILE ANDROID
-| MOBILE IOS
-| BANCOS DE DADOS
-| INICIANTES EM PROGRAMAÇÃO
-| UX DESIGN
-| UI DESIGN
-| ENGENHARIA DE DADOS
-| ANÁLISE DE DADOS
-| SEGURANÇA DA INFORMAÇÃO
-| INFRA (DEVOPS)
-| AGILE
+| TIPO DE MENTORIA  |
+| :--- |
+| FRONT-END |
+| BACK-END |
+| FULL-STACK |
+| MOBILE ANDROID |
+| MOBILE IOS |
+| BANCOS DE DADOS |
+| INICIANTES EM PROGRAMAÇÃO |
+| UX DESIGN |
+| UI DESIGN |
+| GAME DESIGN |
+| PROGRAMAÇÃO FUNCIONAL |
+| ENGENHARIA DE DADOS |
+| ANÁLISE DE DADOS |
+| SEGURANÇA DA INFORMAÇÃO |
+| INFRA (DEVOPS) |
+| AGILE |
 
-Sem algum desses badges nós não aceitaremos o seu PR.
+**IMPORTANTE: Sem pelo menos um desses *badges* nós não aceitaremos o seu PR**.
 
-Depois disso você pode adicionar outras palavras chave que você achar interessante, se limitando a 3 palavras ao todo (contando com o badge principal, que deve ser o primeiro), como:
+Depois disso você pode adicionar outras palavras chave que você achar interessante, se limitando a 3 palavras ao todo (contando com o *badge* principal, que deve ser o primeiro), como:
 
-| TIPO DE MENTORIA 
-| --
-| FRONT-END, REACTJS, ACESSIBILIDADE
-| BACK-END, DJANGO, NOSQL
-| INFRA (DEVOPS), AWS
+| TIPO DE MENTORIA |
+| :--- |
+| FRONT-END / REACTJS / ACESSIBILIDADE |
+| BACK-END / DJANGO / NOSQL |
+| GAME DESIGN / UNITY |
+| PROGRAMAÇÃO FUNCIONAL / HASKELL |

--- a/.github/mentor-list.template.md
+++ b/.github/mentor-list.template.md
@@ -11,7 +11,7 @@ Você pode deixar um link em seu nome com alguma rede social para a pessoa te co
 Por exemplo:
 
 | NOME | TIPO DE MENTORIA | CONTATO |
-| :--- | :--- | :---: |
+| :--- | :--- | :--- |
 | [William Oliveira](https://twitter.com/w_oliveiras) | FRONT-END / NODEJS | [@woliveiras](https://telegram.me/woliveiras) |
 
 **Explicação das colunas**

--- a/mentors-list.md
+++ b/mentors-list.md
@@ -44,12 +44,12 @@ Facebook -> [@user_name](https://www.facebook.com/user_name)
 | [Livia Gabos](http://liviagabos.com) | UX DESIGN / ACESSIBILIDADE / INICIANTES EM PROGRAMAÇÃO | :snowflake: |
 | [Lucas Ricoy](https://github.com/lricoy) | FULL-STACK / JS / FP | :snowflake: |
 | [Alexandre Gaigalas](https://github.com/alganet) | FULL-STACK/PHP/SHELL | [@alganet](https://twitter.com/alganet) |
-| [Júlio Campos](https://linkedin.com/in/jcserracampos) | FULL-STACK/ ANÁLISE DE DADOS | [@jcserracampos](https://telegram.me/jcserracampos) |
+| [Júlio Campos](https://linkedin.com/in/jcserracampos) | FULL-STACK / ANÁLISE DE DADOS | [@jcserracampos](https://telegram.me/jcserracampos) |
 | [Caio Alcantara](https://sourcerer.io/clucasalcantara) | FULL-STACK / JAVASCRIPT / REACT | :snowflake: |
 | [Bruno Matuk](https://github.com/matuklong) | FULL-STACK / AGILE | [@matuklong](https://telegram.me/matuklong) |
 | [Ju Gonçalves](https://cyberglot.me) | FULL-STACK / PROGRAMAÇÃO FUNCIONAL | [@cyberglot](https://twitter.com/cyberglot) |
 | [Juliana Dias](https://about.me/juuh42dias) | BACK-END / RUBY ON RAILS | :snowflake: |
-| [Lauren Ferreira](https://larien.me) | BACK-END/GOLANG | :snowflake: |
+| [Lauren Ferreira](https://larien.me) | BACK-END / GOLANG | :snowflake: |
 | [Mariana Abad](https://github.com/maaryhabad) | FRONT-END / GESTÃO DE PROJETOS | :snowflake: |
 | [Lucas Stoque](https://github.com/stoque) | FRONT-END | :snowflake: |
 | [Matheus Castiglioni](https://github.com/mahenrique94) | FRONT-END | [@mahenrique94](https://telegram.me/mahenrique94) |

--- a/mentors-list.md
+++ b/mentors-list.md
@@ -22,7 +22,7 @@ Facebook -> [@user_name](https://www.facebook.com/user_name)
 
 | NOME | TIPO DE MENTORIA | CONTATO |
 | :--- | :---: | :---: |
-| [Ana Luiza Portello Bastos](https://github.com/anabastos) | FULL-STACK / JAVASCRIPT / FUNCTIONAL PROG. | [@anapbastos](https://telegram.me/anapbastos)/[@naluhh](https://twitter.com/naluhh) |
+| [Ana Luiza Portello Bastos](https://github.com/anabastos) | FULL-STACK / JAVASCRIPT / PROGRAMAÇÃO FUNCIONAL | [@anapbastos](https://telegram.me/anapbastos) / [@naluhh](https://twitter.com/naluhh) |
 | [Francesco Perrotti‑Garcia](https://github.com/fpg1503) | MOBILE IOS / INICIANTES EM PROGRAMAÇÃO / SWIFT | [@fpg1503](https://twitter.com/fpg1503) |
 | [Eduardo Figueiredo Gonçalves](https://github.com/eduardofg87) | FULL-STACK / PHP / JAVASCRIPT | [@eduardofg87](https://telegram.me/eduardofg87) |
 | [Guilherme Gois](https://github.com/guilhermejcgois) | FRONT-END / ANGULAR / TESTES | [@guilhermejcgois](https://twitter.com/guilhermejcgois) |

--- a/mentors-list.md
+++ b/mentors-list.md
@@ -12,39 +12,48 @@ Não acione as pessoas que deixam um :snowflake: na coluna CONTATO, pois as mesm
 
 ## Mentores e mentoras
 
+<!-- TEMPLATES DE LINKS DE CONTATO
 
-| NOME | TIPO DE MENTORIA | MEIO DE CONTATO | CONTATO
-| --- | --- | --- | --- |
-| [Ana Luiza Portello Bastos](https://github.com/anabastos) | FULL-STACK / JAVASCRIPT / FUNCTIONAL PROG. | TELEGRAM/TWITTER | @anapbastos/@naluhh |
-| [Francesco Perrotti‑Garcia](https://github.com/fpg1503) | MOBILE IOS / INICIANTES EM PROGRAMAÇÃO / SWIFT | TWITTER/[SLACK iOS DEV BR](http://iosdevbr.herokuapp.com) | @fpg1503 |
-| [Eduardo Figueiredo Gonçalves](https://github.com/eduardofg87) | FULL-STACK / PHP / JAVASCRIPT | TELEGRAM | @eduardofg87 |
-| [Guilherme Gois](https://twitter.com/guilhermejcgois) | FRONT-END / ANGULAR / TESTES | TWITTER | @guilhermejcgois |
-| [Júlio Fortunato](https://github.com/juliofortunato) | FRONT-END / INICIANTES EM PROGRAMAÇÃO | TELEGRAM | :snowflake: |
-| [Claudson Oliveira](https://github.com/cloudson) |  INICIANTES EM PROGRAMAÇÃO / PHP / BANCOS DE DADOS | TWITTER| :snowflake: |
-| [Elâine Okada](https://twitter.com/okadaelaine) | INICIANTES EM PROGRAMAÇÃO | TELEGRAM | @okadaelaine
-| [Vinícius Alonso](https://github.com/viniciusalonso) | BACK-END / PHP / RUBY | TWITTER | @alonsoemacao |
-| [Giovanni Cruz](https://github.com/giovannicruz97) | FULL-STACK / PHP / JAVASCRIPT | TWITTER/TELEGRAM | :snowflake: |
-| [Marcelo Duarte Trevisani](https://www.linkedin.com/in/marcelodtrevisani/) | BACK-END / PYTHON / C++ | TELEGRAM | @marcelotrevisani |
-| [Chico Venancio](https://twitter.com/chicocvenancio) | INFRA (DEVOPS)| TELEGRAM/TWITTER | @chicocvenancio|
-| [Bruno Alano](https://github.com/brunoalano) | DEEP LEARNING / FULL-STACK / CRYPTO | TELEGRAM | @brunoalano |
-| [Bianca Rosa](http://biancarosa.com.br/) | BACK-END / PYTHON / TESTES | TELEGRAM | @bianca_rosa |
-| [Maurício Antunes](https://www.maugzoide.com/) | BACK-END / WEBSERVERS / PYTHON | TWITTER | @maugzoide
-| [Juliana Negreiros](https://twitter.com/juunegreiros) |  FRONT-END/INICIANTES EM PROGRAMAÇÃO/INICIANTES EM DESENVOLVIMENTO DE JOGOS | TELEGRAM/TWITTER | :snowflake: |
-| [Ana Paula Gomes](https://anapaulagomes.me) | BACK-END/PYTHON | TELEGRAM/TWITTER | :snowflake: |
-| [Thaly](https://twitter.com/AtemZero) | UX DESIGN / GAME DESIGN / EMPREENDEDORISMO | TWITTER/TELEGRAM | :snowflake: |
-| [Marcos Felipe](https://github.com/omarkdev) | FULL-STACK / PHP / JAVASCRIPT | TELEGRAM/TWITTER | :snowflake: |
-| [Glauber Sampaio](https://www.linkedin.com/in/glaubersampaio/) | AGILE / INICIANTES EM PROGRAMAÇÃO | TWITTER | :snowflake: |
-| [Livia Gabos](http://liviagabos.com) | UX DESIGN / ACESSIBILIDADE / INICIANTES EM PROGRAMAÇÃO | TWITTER/TELEGRAM/SLACK | :snowflake: |
-| [Lucas Ricoy](https://github.com/lricoy) | FULL-STACK / JS / FP | TELEGRAM | :snowflake: |
-| [Alexandre Gaigalas](https://github.com/alganet) | FULL-STACK/PHP/SHELL | TWITTER | @alganet |
-| [Júlio Campos](https://linkedin.com/in/jcserracampos) | FULL-STACK/ ANÁLISE DE DADOS | TELEGRAM/TWITTER | @jcserracampos |
-| [Caio Alcantara](https://sourcerer.io/clucasalcantara) | FULL-STACK / JAVASCRIPT (REACT) | TELEGRAM/TWITTER | :snowflake: |
-| [Bruno Matuk](https://github.com/matuklong) | FULL-STACK / AGILE | TELEGRAM | @matuklong |
-| [Ju Gonçalves](https://cyberglot.me) | FULL-STACK / FUNCTIONAL PROG. | TWITTER | @cyberglot |
-| [Juliana Dias](https://about.me/juuh42dias) | BACK-END/RUBY(ON RAILS) | TELEGRAM/TWITTER | :snowflake: |
-| [Lauren Ferreira](https://larien.me) | BACK-END/GOLANG | TELEGRAM/TWITTER | :snowflake: |
-| [Mariana Abad](https://github.com/maaryhabad) | FRONT-END / GESTÃO DE PROJETOS | TELEGRAM | :snowflake: |
-| [Lucas Stoque](https://github.com/stoque) | FRONT-END | TELEGRAM | :snowflake: |
-| [Matheus Castiglioni](https://github.com/mahenrique94) | FRONT-END | TELEGRAM | @mahenrique94 |
-| [Clayton Silva](https://github.com/claytonsilva) | INFRA (DEVOPS) | TELEGRAM | @claytonssilva |
-| [William Oliveira](https://twitter.com/w_oliveiras) | FRONT-END / NODEJS | TELEGRAM | :snowflake: |
+Twitter -> [@user_name](https://twitter.com/user_name)
+Telegram -> [@user_name](https://telegram.me/user_name)
+Facebook -> [@user_name](https://www.facebook.com/user_name)
+
+-->
+
+| NOME | TIPO DE MENTORIA | CONTATO |
+| :--- | :---: | :---: |
+| [Ana Luiza Portello Bastos](https://github.com/anabastos) | FULL-STACK / JAVASCRIPT / FUNCTIONAL PROG. | [@anapbastos](https://telegram.me/anapbastos)/[@naluhh](https://twitter.com/naluhh) |
+| [Francesco Perrotti‑Garcia](https://github.com/fpg1503) | MOBILE IOS / INICIANTES EM PROGRAMAÇÃO / SWIFT | [@fpg1503](https://twitter.com/fpg1503) |
+| [Eduardo Figueiredo Gonçalves](https://github.com/eduardofg87) | FULL-STACK / PHP / JAVASCRIPT | [@eduardofg87](https://telegram.me/eduardofg87) |
+| [Guilherme Gois](https://github.com/guilhermejcgois) | FRONT-END / ANGULAR / TESTES | [@guilhermejcgois](https://twitter.com/guilhermejcgois) |
+| [Júlio Fortunato](https://github.com/juliofortunato) | FRONT-END / INICIANTES EM PROGRAMAÇÃO| :snowflake: |
+| [Claudson Oliveira](https://github.com/cloudson) |  INICIANTES EM PROGRAMAÇÃO / PHP / BANCOS DE DADOS | :snowflake: |
+| [Elâine Okada](https://twitter.com/okadaelaine) | INICIANTES EM PROGRAMAÇÃO | [@okadaelaine](https://telegram.me/okadaelaine) |
+| [Vinícius Alonso](https://github.com/viniciusalonso) | BACK-END / PHP / RUBY | [@alonsoemacao](https://twitter.com/alonsoemacao) |
+| [Giovanni Cruz](https://github.com/giovannicruz97) | FULL-STACK / PHP / JAVASCRIPT | :snowflake: |
+| [Marcelo Duarte Trevisani](https://www.linkedin.com/in/marcelodtrevisani/) | BACK-END / PYTHON / C++ | [@marcelotrevisani](https://telegram.me/marcelotrevisani) |
+| [Chico Venancio](https://twitter.com/chicocvenancio) | INFRA (DEVOPS)| [@chicocvenancio](https://telegram.me/chicocvenancio) |
+| [Bruno Alano](https://github.com/brunoalano) | DEEP LEARNING / FULL-STACK / CRYPTO | [@brunoalano](https://telegram.me/brunoalano) |
+| [Bianca Rosa](http://biancarosa.com.br/) | BACK-END / PYTHON / TESTES | [@bianca_rosa](https://telegram.me/bianca_rosa) |
+| [Maurício Antunes](https://www.maugzoide.com/) | BACK-END / WEBSERVERS / PYTHON | [@maugzoide](https://twitter.com/maugzoide) |
+| [Juliana Negreiros](https://twitter.com/juunegreiros) |  FRONT-END / INICIANTES EM PROGRAMAÇÃO / INICIANTES EM GAME DESIGN | :snowflake: |
+| [Ana Paula Gomes](https://anapaulagomes.me) | BACK-END/PYTHON | :snowflake: |
+| [Thaly](https://twitter.com/AtemZero) | UX DESIGN / GAME DESIGN / EMPREENDEDORISMO | :snowflake: |
+| [Marcos Felipe](https://github.com/omarkdev) | FULL-STACK / PHP / JAVASCRIPT  | :snowflake: |
+| [Glauber Sampaio](https://www.linkedin.com/in/glaubersampaio/) | AGILE / INICIANTES EM PROGRAMAÇÃO | :snowflake: |
+| [Livia Gabos](http://liviagabos.com) | UX DESIGN / ACESSIBILIDADE / INICIANTES EM PROGRAMAÇÃO | :snowflake: |
+| [Lucas Ricoy](https://github.com/lricoy) | FULL-STACK / JS / FP | :snowflake: |
+| [Alexandre Gaigalas](https://github.com/alganet) | FULL-STACK/PHP/SHELL | [@alganet](https://twitter.com/alganet) |
+| [Júlio Campos](https://linkedin.com/in/jcserracampos) | FULL-STACK/ ANÁLISE DE DADOS | [@jcserracampos](https://telegram.me/jcserracampos) |
+| [Caio Alcantara](https://sourcerer.io/clucasalcantara) | FULL-STACK / JAVASCRIPT / REACT | :snowflake: |
+| [Bruno Matuk](https://github.com/matuklong) | FULL-STACK / AGILE | [@matuklong](https://telegram.me/matuklong) |
+| [Ju Gonçalves](https://cyberglot.me) | FULL-STACK / PROGRAMAÇÃO FUNCIONAL | [@cyberglot](https://twitter.com/cyberglot) |
+| [Juliana Dias](https://about.me/juuh42dias) | BACK-END / RUBY ON RAILS | :snowflake: |
+| [Lauren Ferreira](https://larien.me) | BACK-END/GOLANG | :snowflake: |
+| [Mariana Abad](https://github.com/maaryhabad) | FRONT-END / GESTÃO DE PROJETOS | :snowflake: |
+| [Lucas Stoque](https://github.com/stoque) | FRONT-END | :snowflake: |
+| [Matheus Castiglioni](https://github.com/mahenrique94) | FRONT-END | [@mahenrique94](https://telegram.me/mahenrique94) |
+| [Clayton Silva](https://github.com/claytonsilva) | INFRA (DEVOPS) | [@claytonssilva](https://telegram.me/claytonssilva) |
+| [William Oliveira](https://twitter.com/w_oliveiras) | FRONT-END / NODEJS | :snowflake: |
+
+<!-- NÃO ADICIONE SEU NOME NO FINAL DA LISTA, NOVOS MENTORES DEVEM SER ADICIONADOS NO INÍCIO DA LISTA -->

--- a/mentors-list.md
+++ b/mentors-list.md
@@ -21,7 +21,7 @@ Facebook -> [@user_name](https://www.facebook.com/user_name)
 -->
 
 | NOME | TIPO DE MENTORIA | CONTATO |
-| :--- | :---: | :---: |
+| :--- | :--- | :--- |
 | [Ana Luiza Portello Bastos](https://github.com/anabastos) | FULL-STACK / JAVASCRIPT / PROGRAMAÇÃO FUNCIONAL | [@anapbastos](https://telegram.me/anapbastos) / [@naluhh](https://twitter.com/naluhh) |
 | [Francesco Perrotti‑Garcia](https://github.com/fpg1503) | MOBILE IOS / INICIANTES EM PROGRAMAÇÃO / SWIFT | [@fpg1503](https://twitter.com/fpg1503) |
 | [Eduardo Figueiredo Gonçalves](https://github.com/eduardofg87) | FULL-STACK / PHP / JAVASCRIPT | [@eduardofg87](https://telegram.me/eduardofg87) |


### PR DESCRIPTION
## Objetivos deste PR

Atualizar a lista de mentores para que fique ela fique mais intuitiva e prática.

## O que foi alterado

* removida coluna que indicava site do meio de contato
* adicionado link aos meios de contato
* adicionado comentários para auxiliar novos mentores

## Como validar

@woliveiras ou quem mais puder, dá uma conferida :)

[PREVIEW MAROTO DA LISTA](https://github.com/luizbills/mentoria/blob/patch-5/mentors-list.md)
[PREVIEW MAROTO DO TEMPLATE](https://github.com/luizbills/mentoria/blob/patch-5/.github/mentor-list.template.md)
